### PR TITLE
chore: Remove external dns deprecated variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@
 | <a name="input_csi_secrets_store_provider_aws_helm_config"></a> [csi\_secrets\_store\_provider\_aws\_helm\_config](#input\_csi\_secrets\_store\_provider\_aws\_helm\_config) | CSI Secrets Store Provider AWS Helm Configurations | `any` | `null` | no |
 | <a name="input_custom_image_registry_uri"></a> [custom\_image\_registry\_uri](#input\_custom\_image\_registry\_uri) | Custom image registry URI map of `{region = dkr.endpoint }` | `map(string)` | `{}` | no |
 | <a name="input_data_plane_wait_arn"></a> [data\_plane\_wait\_arn](#input\_data\_plane\_wait\_arn) | Addon deployment will not proceed until this value is known. Set to node group/Fargate profile ARN to wait for data plane to be ready before provisioning addons | `string` | `""` | no |
-| <a name="input_eks_cluster_domain"></a> [eks\_cluster\_domain](#input\_eks\_cluster\_domain) | The domain for the EKS cluster | `string` | `""` | no |
 | <a name="input_eks_cluster_endpoint"></a> [eks\_cluster\_endpoint](#input\_eks\_cluster\_endpoint) | Endpoint for your Kubernetes API server | `string` | `null` | no |
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | EKS Cluster Id | `string` | n/a | yes |
 | <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | The Kubernetes version for the cluster | `string` | `null` | no |
@@ -155,7 +154,6 @@
 | <a name="input_enable_vpa"></a> [enable\_vpa](#input\_enable\_vpa) | Enable Vertical Pod Autoscaler add-on | `bool` | `false` | no |
 | <a name="input_external_dns_helm_config"></a> [external\_dns\_helm\_config](#input\_external\_dns\_helm\_config) | External DNS Helm Chart config | `any` | `{}` | no |
 | <a name="input_external_dns_irsa_policies"></a> [external\_dns\_irsa\_policies](#input\_external\_dns\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
-| <a name="input_external_dns_private_zone"></a> [external\_dns\_private\_zone](#input\_external\_dns\_private\_zone) | Determines if referenced Route53 zone is private. | `bool` | `false` | no |
 | <a name="input_external_dns_route53_zone_arns"></a> [external\_dns\_route53\_zone\_arns](#input\_external\_dns\_route53\_zone\_arns) | List of Route53 zones ARNs which external-dns will have access to create/manage records | `list(string)` | `[]` | no |
 | <a name="input_external_secrets_helm_config"></a> [external\_secrets\_helm\_config](#input\_external\_secrets\_helm\_config) | External Secrets operator Helm Chart config | `any` | `{}` | no |
 | <a name="input_external_secrets_irsa_policies"></a> [external\_secrets\_irsa\_policies](#input\_external\_secrets\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -313,8 +313,6 @@ module "external_dns" {
   irsa_policies     = var.external_dns_irsa_policies
   addon_context     = local.addon_context
 
-  domain_name       = var.eks_cluster_domain
-  private_zone      = var.external_dns_private_zone
   route53_zone_arns = var.external_dns_route53_zone_arns
 }
 

--- a/modules/external-dns/README.md
+++ b/modules/external-dns/README.md
@@ -32,18 +32,15 @@ For complete project documentation, please visit the [ExternalDNS Github reposit
 |------|------|
 | [aws_iam_policy.external_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy_document.external_dns_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_route53_zone.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>    irsa_iam_role_path             = string<br>    irsa_iam_permissions_boundary  = string<br>  })</pre> | n/a | yes |
-| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | [Deprecated - use `route53_zone_arns`] Domain name of the Route53 hosted zone to use with External DNS. | `string` | n/a | yes |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | External DNS Helm Configuration | `any` | `{}` | no |
 | <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | Additional IAM policies used for the add-on service account. | `list(string)` | `[]` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
-| <a name="input_private_zone"></a> [private\_zone](#input\_private\_zone) | [Deprecated - use `route53_zone_arns`] Determines if referenced Route53 hosted zone is private. | `bool` | `false` | no |
 | <a name="input_route53_zone_arns"></a> [route53\_zone\_arns](#input\_route53\_zone\_arns) | List of Route53 zones ARNs which external-dns will have access to create/manage records | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/modules/external-dns/data.tf
+++ b/modules/external-dns/data.tf
@@ -1,10 +1,7 @@
 data "aws_iam_policy_document" "external_dns_iam_policy_document" {
   statement {
     effect = "Allow"
-    resources = distinct(concat(
-      [data.aws_route53_zone.selected.arn],
-      var.route53_zone_arns
-    ))
+    resources = distinct(var.route53_zone_arns)
     actions = [
       "route53:ChangeResourceRecordSets",
       "route53:ListResourceRecordSets",

--- a/modules/external-dns/data.tf
+++ b/modules/external-dns/data.tf
@@ -1,6 +1,6 @@
 data "aws_iam_policy_document" "external_dns_iam_policy_document" {
   statement {
-    effect = "Allow"
+    effect    = "Allow"
     resources = distinct(var.route53_zone_arns)
     actions = [
       "route53:ChangeResourceRecordSets",

--- a/modules/external-dns/main.tf
+++ b/modules/external-dns/main.tf
@@ -72,9 +72,3 @@ resource "aws_iam_policy" "external_dns" {
   policy      = data.aws_iam_policy_document.external_dns_iam_policy_document.json
   tags        = var.addon_context.tags
 }
-
-# TODO - remove at next breaking change
-data "aws_route53_zone" "selected" {
-  name         = var.domain_name
-  private_zone = var.private_zone
-}

--- a/modules/external-dns/variables.tf
+++ b/modules/external-dns/variables.tf
@@ -16,17 +16,6 @@ variable "irsa_policies" {
   default     = []
 }
 
-variable "domain_name" {
-  description = "[Deprecated - use `route53_zone_arns`] Domain name of the Route53 hosted zone to use with External DNS."
-  type        = string
-}
-
-variable "private_zone" {
-  description = "[Deprecated - use `route53_zone_arns`] Determines if referenced Route53 hosted zone is private."
-  type        = bool
-  default     = false
-}
-
 variable "route53_zone_arns" {
   description = "List of Route53 zones ARNs which external-dns will have access to create/manage records"
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -3,12 +3,6 @@ variable "eks_cluster_id" {
   type        = string
 }
 
-variable "eks_cluster_domain" {
-  description = "The domain for the EKS cluster"
-  type        = string
-  default     = ""
-}
-
 variable "data_plane_wait_arn" {
   description = "Addon deployment will not proceed until this value is known. Set to node group/Fargate profile ARN to wait for data plane to be ready before provisioning addons"
   type        = string
@@ -190,12 +184,6 @@ variable "external_dns_irsa_policies" {
   description = "Additional IAM policies for a IAM role for service accounts"
   type        = list(string)
   default     = []
-}
-
-variable "external_dns_private_zone" {
-  type        = bool
-  description = "Determines if referenced Route53 zone is private."
-  default     = false
 }
 
 variable "external_dns_route53_zone_arns" {


### PR DESCRIPTION
### What does this PR do?

Remove the deprecated variable for external-dns addon

### Motivation

- Resolves #64 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
