### PR TITLE
feat: Add support for argocd centralized multi-cluster example

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Please note: not all addons will be supported as they are today in the main EKS 
 | <a name="output_argo_rollouts"></a> [argo\_rollouts](#output\_argo\_rollouts) | Map of attributes of the Helm release created |
 | <a name="output_argo_workflows"></a> [argo\_workflows](#output\_argo\_workflows) | Map of attributes of the Helm release created |
 | <a name="output_argocd"></a> [argocd](#output\_argocd) | Map of attributes of the Helm release created |
+| <a name="output_argocd_addon_config"></a> [argocd\_addon\_config](#output\_argocd\_addon\_config) | ArgoCD addon config options |
 | <a name="output_aws_efs_csi_driver"></a> [aws\_efs\_csi\_driver](#output\_aws\_efs\_csi\_driver) | Map of attributes of the Helm release and IRSA created |
 | <a name="output_aws_for_fluent_bit"></a> [aws\_for\_fluent\_bit](#output\_aws\_for\_fluent\_bit) | Map of attributes of the Helm release and IRSA created |
 | <a name="output_aws_fsx_csi_driver"></a> [aws\_fsx\_csi\_driver](#output\_aws\_fsx\_csi\_driver) | Map of attributes of the Helm release and IRSA created |

--- a/modules/argocd/README.md
+++ b/modules/argocd/README.md
@@ -48,8 +48,9 @@ Application definitions, configurations, and environments should be declarative 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_addon_config"></a> [addon\_config](#input\_addon\_config) | Configuration for managing add-ons via ArgoCD | `any` | `{}` | no |
-| <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | <pre>object({<br>    aws_caller_identity_account_id = string<br>    aws_caller_identity_arn        = string<br>    aws_eks_cluster_endpoint       = string<br>    aws_partition_id               = string<br>    aws_region_name                = string<br>    eks_cluster_id                 = string<br>    eks_oidc_issuer_url            = string<br>    eks_oidc_provider_arn          = string<br>    tags                           = map(string)<br>  })</pre> | n/a | yes |
+| <a name="input_addon_context"></a> [addon\_context](#input\_addon\_context) | Input configuration for the addon | `any` | `{}` | no |
 | <a name="input_applications"></a> [applications](#input\_applications) | ArgoCD Application config used to bootstrap a cluster. | `any` | `{}` | no |
+| <a name="input_argocd_skip_install"></a> [argocd\_skip\_install](#input\_argocd\_skip\_install) | Skips Installation of ArgoCD addon/controller | `bool` | `false` | no |
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | ArgoCD Helm Chart Config values | `any` | `{}` | no |
 
 ## Outputs

--- a/modules/argocd/argocd-application/helm/templates/application.yaml
+++ b/modules/argocd/argocd-application/helm/templates/application.yaml
@@ -2,7 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: {{ .Values.name }}
-  namespace: {{ .Values.namespace }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/modules/argocd/locals.tf
+++ b/modules/argocd/locals.tf
@@ -9,7 +9,7 @@ locals {
     name             = local.name
     chart            = local.name
     repository       = "https://argoproj.github.io/argo-helm"
-    version          = "5.27.0"
+    version          = "5.27.1" # ArgoCD v2.6.6
     namespace        = local.namespace
     create_namespace = true
     values           = local.default_helm_values

--- a/modules/argocd/locals.tf
+++ b/modules/argocd/locals.tf
@@ -15,6 +15,7 @@ locals {
     values           = local.default_helm_values
     description      = "The ArgoCD Helm Chart deployment configuration"
     wait             = false
+    timeout          = 1200
   }
 
   helm_config = merge(

--- a/modules/argocd/main.tf
+++ b/modules/argocd/main.tf
@@ -25,6 +25,7 @@ resource "helm_release" "argocd_application" {
   chart     = "${path.module}/argocd-application/helm"
   version   = "1.0.0"
   namespace = local.helm_config["namespace"]
+  timeout   = local.helm_config["timeout"]
 
   # Application Meta.
   set {

--- a/modules/argocd/main.tf
+++ b/modules/argocd/main.tf
@@ -68,8 +68,8 @@ resource "helm_release" "argocd_application" {
     name = "source.helm.values"
     value = yamlencode(merge(
       { repoUrl = each.value.repo_url },
-      local.global_application_values,
       each.value.values,
+      local.global_application_values,
       { for k, v in var.addon_config : k => v if each.value.add_on_application }
     ))
     type = "auto"

--- a/modules/argocd/main.tf
+++ b/modules/argocd/main.tf
@@ -1,4 +1,5 @@
 module "helm_addon" {
+  count  = !var.argocd_skip_install ? 1 : 0
   source = "../helm-addon"
 
   helm_config   = local.helm_config
@@ -8,7 +9,7 @@ module "helm_addon" {
 }
 
 resource "kubernetes_namespace_v1" "this" {
-  count = try(local.helm_config["create_namespace"], true) && local.helm_config["namespace"] != "kube-system" ? 1 : 0
+  count = length(var.addon_config) != 0 && try(local.helm_config["create_namespace"], true) && local.helm_config["namespace"] != "kube-system" ? 1 : 0
   metadata {
     name = local.helm_config["namespace"]
   }
@@ -67,9 +68,9 @@ resource "helm_release" "argocd_application" {
     name = "source.helm.values"
     value = yamlencode(merge(
       { repoUrl = each.value.repo_url },
-      each.value.values,
       local.global_application_values,
-      each.value.add_on_application ? var.addon_config : {}
+      each.value.values,
+      { for k, v in var.addon_config : k => v if each.value.add_on_application }
     ))
     type = "auto"
   }
@@ -78,6 +79,12 @@ resource "helm_release" "argocd_application" {
   set {
     name  = "destination.server"
     value = each.value.destination
+    type  = "string"
+  }
+
+  set {
+    name  = "namespace"
+    value = each.value.namespace
     type  = "string"
   }
 
@@ -121,8 +128,8 @@ resource "kubernetes_secret" "argocd_gitops" {
   for_each = { for k, v in var.applications : k => v if try(v.ssh_key_secret_name, null) != null }
 
   metadata {
-    name      = "${each.key}-repo-secret"
-    namespace = local.helm_config["namespace"]
+    name      = lookup(each.value, "git_secret_name", "${each.key}-repo-secret")
+    namespace = lookup(each.value, "git_secret_namespace", local.helm_config["namespace"])
     labels    = { "argocd.argoproj.io/secret-type" : "repository" }
   }
 

--- a/modules/argocd/outputs.tf
+++ b/modules/argocd/outputs.tf
@@ -1,19 +1,19 @@
 output "release_metadata" {
   description = "Map of attributes of the Helm release metadata"
-  value       = module.helm_addon.release_metadata
+  value       = try(module.helm_addon[0].release_metadata, null)
 }
 
 output "irsa_arn" {
   description = "IAM role ARN for the service account"
-  value       = module.helm_addon.irsa_arn
+  value       = try(module.helm_addon[0].irsa_arn, null)
 }
 
 output "irsa_name" {
   description = "IAM role name for the service account"
-  value       = module.helm_addon.irsa_name
+  value       = try(module.helm_addon[0].irsa_name, null)
 }
 
 output "service_account" {
   description = "Name of Kubernetes service account"
-  value       = module.helm_addon.service_account
+  value       = try(module.helm_addon[0].service_account, null)
 }

--- a/modules/argocd/variables.tf
+++ b/modules/argocd/variables.tf
@@ -18,15 +18,12 @@ variable "addon_config" {
 
 variable "addon_context" {
   description = "Input configuration for the addon"
-  type = object({
-    aws_caller_identity_account_id = string
-    aws_caller_identity_arn        = string
-    aws_eks_cluster_endpoint       = string
-    aws_partition_id               = string
-    aws_region_name                = string
-    eks_cluster_id                 = string
-    eks_oidc_issuer_url            = string
-    eks_oidc_provider_arn          = string
-    tags                           = map(string)
-  })
+  type        = any
+  default     = {}
+}
+
+variable "argocd_skip_install" {
+  description = "Skips Installation of ArgoCD addon/controller"
+  type        = bool
+  default     = false
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "argocd" {
   value       = try(module.argocd[0], null)
 }
 
+output "argocd_addon_config" {
+  description = "ArgoCD addon config options"
+  value       = local.argocd_addon_config
+}
+
 output "argo_rollouts" {
   description = "Map of attributes of the Helm release created"
   value       = module.argo_rollouts


### PR DESCRIPTION
### What does this PR do?

This allows the argocd module to be use to generate argocd apps for addons on spoke clusters, skipping the installation of argocd controller on spoke clusters

### Motivation

- Dependency for https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/1425

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
