### PR TITLE
fix: Add `read` permission for PRs to `pr-title` workflow

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -13,8 +13,10 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.0.2
+      - uses: amannn/action-semantic-pull-request@v5.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
### What does this PR do?

- Add `read` permission for PRs to `pr-title` workflow. I think this will work, not sure why the default, top-level `read-all` doesn't work
	- Ref: https://github.com/amannn/action-semantic-pull-request/pull/215

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
