### PR TITLE
fix: Fix policy reference when var.enable_efs_csi_driver is false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -384,7 +384,7 @@ module "efs_csi_driver" {
   role_description              = try(var.efs_csi_driver.role_description, "IRSA for aws-efs-csi-driver project")
 
   role_policy_arns = try(var.efs_csi_driver.role_policy_arns,
-    { EfsCsiDriverPolicy = aws_iam_policy.efs_csi_driver[0].arn }
+    { EfsCsiDriverPolicy = try(aws_iam_policy.efs_csi_driver[0].arn, null) }
   )
 
   oidc_providers = {


### PR DESCRIPTION
### What does this PR do?

Error out of the box with efs-csi-driver is false

### Motivation

Got the following error on `terraform plan`
```
╷
│ Error: Error in function call
│ 
│   on .terraform/modules/eks_blueprints_kubernetes_addons/main.tf line 386, in module "efs_csi_driver":
│  386:   role_policy_arns = try(var.efs_csi_driver.role_policy_arns,
│  387:     { EfsCsiDriverPolicy = aws_iam_policy.efs_csi_driver[0].arn }
│  388:   )
│     ├────────────────
│     │ while calling try(expressions...)
│     │ aws_iam_policy.efs_csi_driver is empty tuple
│     │ var.efs_csi_driver is object with no attributes
│ 
│ Call to function "try" failed: no expression succeeded:
│ - Unsupported attribute (at .terraform/modules/eks_blueprints_kubernetes_addons/main.tf:386,44-61)
│   This object does not have an attribute named "role_policy_arns".
│ - Invalid index (at .terraform/modules/eks_blueprints_kubernetes_addons/main.tf:387,57-60)
│   The given key does not identify an element in this collection value: the collection has no elements.
│ 
│ At least one expression must produce a successful result.

```

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
