### PR TITLE
fix: Cluster Autoscaler IRSA policy update to handle Managed Node scaling from Zero 

### DIFF
--- a/modules/cluster-autoscaler/data.tf
+++ b/modules/cluster-autoscaler/data.tf
@@ -55,11 +55,5 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
     actions = [
       "eks:DescribeNodegroup",
     ]
-
-    condition {
-      test     = "StringEquals"
-      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/${var.addon_context.eks_cluster_id}"
-      values   = ["owned"]
-    }
   }
 }


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

- Removing a condition that causing a Access Denied error for Cluster Autoscaler pod to talk to EKS API.
- Please checkout the issue #89 for more details


### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>
#89 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
