### PR TITLE
fix: Remove namespace creation

### DIFF
--- a/modules/kube-prometheus-stack/main.tf
+++ b/modules/kube-prometheus-stack/main.tf
@@ -13,11 +13,12 @@ module "helm_addon" {
 
   helm_config = merge(
     {
-      name       = local.name
-      chart      = local.name
-      repository = "https://prometheus-community.github.io/helm-charts"
-      version    = "45.7.1"
-      namespace  = local.namespace
+      name             = local.name
+      chart            = local.name
+      repository       = "https://prometheus-community.github.io/helm-charts"
+      version          = "45.7.1"
+      namespace        = local.namespace
+      create_namespace = local.namespace != "kube-system" ? try(var.helm_config.create_namespace, true) : false
       values = [templatefile("${path.module}/values.yaml", {
         aws_region = var.addon_context.aws_region_name
       })]

--- a/modules/kube-prometheus-stack/main.tf
+++ b/modules/kube-prometheus-stack/main.tf
@@ -7,12 +7,6 @@ locals {
   }
 }
 
-resource "kubernetes_namespace_v1" "prometheus" {
-  metadata {
-    name = local.namespace
-  }
-}
-
 # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/Chart.yaml
 module "helm_addon" {
   source = "../helm-addon"
@@ -23,7 +17,7 @@ module "helm_addon" {
       chart      = local.name
       repository = "https://prometheus-community.github.io/helm-charts"
       version    = "45.7.1"
-      namespace  = kubernetes_namespace_v1.prometheus.metadata[0].name
+      namespace  = local.namespace
       values = [templatefile("${path.module}/values.yaml", {
         aws_region = var.addon_context.aws_region_name
       })]

--- a/modules/kube-prometheus-stack/versions.tf
+++ b/modules/kube-prometheus-stack/versions.tf
@@ -1,10 +1,3 @@
 terraform {
   required_version = ">= 1.0.0"
-
-  required_providers {
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.10"
-    }
-  }
 }


### PR DESCRIPTION
### What does this PR do?

Remove namespace creation to allow deployments to an already-existing namespace. `create_namespace` should be used to create namespaces rather than a resource.

https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/issues/102

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #102 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
