### PR TITLE
fix: Added clusterName to alb as its a mandatory value

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -992,7 +992,7 @@ module "aws_load_balancer_controller" {
     {
       name  = "controller.serviceAccount.name"
       value = local.aws_load_balancer_controller_service_account
-    },{
+      }, {
       name  = "clusterName"
       value = var.cluster_name
     }],

--- a/main.tf
+++ b/main.tf
@@ -992,6 +992,9 @@ module "aws_load_balancer_controller" {
     {
       name  = "controller.serviceAccount.name"
       value = local.aws_load_balancer_controller_service_account
+    },{
+      name  = "clusterName"
+      value = var.cluster_name
     }],
     try(var.aws_load_balancer_controller.set, [])
   )


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

- Added a fix for ALB controller addon to set clusterName

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #105 

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
