### PR TITLE
fix: Wrap attribute lookup in `try()` to avoid error when Karpenter is not enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1744,7 +1744,7 @@ locals {
   karpenter_service_account_name    = try(var.karpenter.service_account_name, "karpenter")
   karpenter_enable_spot_termination = var.enable_karpenter && var.karpenter_enable_spot_termination
   create_karpenter_instance_profile = try(var.karpenter_instance_profile.create, true)
-  karpenter_instance_profile_name   = local.create_karpenter_instance_profile ? aws_iam_instance_profile.karpenter[0].arn : var.karpenter_instance_profile.name
+  karpenter_instance_profile_name   = try(aws_iam_instance_profile.karpenter[0].arn, var.karpenter_instance_profile.name, "")
 }
 
 data "aws_iam_policy_document" "karpenter" {

--- a/variables.tf
+++ b/variables.tf
@@ -383,6 +383,7 @@ variable "aws_for_fluentbit_cw_log_group" {
 ################################################################################
 # AWS Private CA Issuer
 ################################################################################
+
 variable "enable_aws_privateca_issuer" {
   description = "Enable AWS PCA Issuer"
   type        = bool
@@ -401,10 +402,10 @@ variable "aws_privateca_issuer" {
   default     = {}
 }
 
-
 ################################################################################
 # Metrics Server
 ################################################################################
+
 variable "enable_metrics_server" {
   description = "Enable metrics server add-on"
   type        = bool


### PR DESCRIPTION
### What does this PR do?

- Wrap attribute lookup in `try()` to avoid error when Karpenter is not enabled

### Motivation

- Avoid error when Karpenter is not enabled

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
