### PR TITLE
feat: Add FSx for NetApp ONTAP CSI add-on

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1466,6 +1466,58 @@ module "fsx_csi_driver" {
 }
 
 ################################################################################
+# FSX NETAPP ONTAP CSI DRIVER
+################################################################################
+
+module "fsx_csi_driver" {
+  # source = "aws-ia/eks-blueprints-addon/aws"
+  source = "./modules/eks-blueprints-addon"
+
+  create = var.enable_fsxn_csi_driver
+
+  # https://netapp.github.io/trident-helm-chart
+  name             = try(var.fsxn_csi_driver.name, "trident-operator")
+  description      = try(var.fsxn_csi_driver.description, "Amazon FSx for NetApp ONTAP CSI storage provisioner using the Trident Operator.")
+  namespace        = try(var.fsxn_csi_driver.namespace, "trident")
+  create_namespace = try(var.fsxn_csi_driver.create_namespace, true)
+  chart            = "trident-operator"
+  chart_version    = try(var.fsxn_csi_driver.chart_version, "23.01.0")
+  repository       = try(var.fsxn_csi_driver.repository, "https://netapp.github.io/trident-helm-chart")
+  values           = try(var.fsxn_csi_driver.values, [])
+
+  timeout                    = try(var.fsxn_csi_driver.timeout, null)
+  repository_key_file        = try(var.fsxn_csi_driver.repository_key_file, null)
+  repository_cert_file       = try(var.fsxn_csi_driver.repository_cert_file, null)
+  repository_ca_file         = try(var.fsxn_csi_driver.repository_ca_file, null)
+  repository_username        = try(var.fsxn_csi_driver.repository_username, null)
+  repository_password        = try(var.fsxn_csi_driver.repository_password, null)
+  devel                      = try(var.fsxn_csi_driver.devel, null)
+  verify                     = try(var.fsxn_csi_driver.verify, null)
+  keyring                    = try(var.fsxn_csi_driver.keyring, null)
+  disable_webhooks           = try(var.fsxn_csi_driver.disable_webhooks, null)
+  reuse_values               = try(var.fsxn_csi_driver.reuse_values, null)
+  reset_values               = try(var.fsxn_csi_driver.reset_values, null)
+  force_update               = try(var.fsxn_csi_driver.force_update, null)
+  recreate_pods              = try(var.fsxn_csi_driver.recreate_pods, null)
+  cleanup_on_fail            = try(var.fsxn_csi_driver.cleanup_on_fail, null)
+  max_history                = try(var.fsxn_csi_driver.max_history, null)
+  atomic                     = try(var.fsxn_csi_driver.atomic, null)
+  skip_crds                  = try(var.fsxn_csi_driver.skip_crds, null)
+  render_subchart_notes      = try(var.fsxn_csi_driver.render_subchart_notes, null)
+  disable_openapi_validation = try(var.fsxn_csi_driver.disable_openapi_validation, null)
+  wait                       = try(var.fsxn_csi_driver.wait, null)
+  wait_for_jobs              = try(var.fsxn_csi_driver.wait_for_jobs, null)
+  dependency_update          = try(var.fsxn_csi_driver.dependency_update, null)
+  replace                    = try(var.fsxn_csi_driver.replace, null)
+  lint                       = try(var.fsxn_csi_driver.lint, null)
+
+  postrender = try(var.fsxn_csi_driver.postrender, [])
+  set = try(var.fsxn_csi_driver.set, [])
+  set_sensitive = try(var.fsxn_csi_driver.set_sensitive, [])
+  
+}
+
+################################################################################
 # Secrets Store CSI Driver
 ################################################################################
 

--- a/main.tf
+++ b/main.tf
@@ -1469,7 +1469,7 @@ module "fsx_csi_driver" {
 # FSX NETAPP ONTAP CSI DRIVER
 ################################################################################
 
-module "fsx_csi_driver" {
+module "fsxn_csi_driver" {
   # source = "aws-ia/eks-blueprints-addon/aws"
   source = "./modules/eks-blueprints-addon"
 

--- a/variables.tf
+++ b/variables.tf
@@ -392,6 +392,26 @@ variable "fsx_csi_driver" {
   default     = {}
 }
 
+#-----------AWS FSX NETAPP CSI DRIVER ADDON-------------
+
+variable "enable_fsxn_csi_driver" {
+  description = "Enable AWS FSX NETAPP ONTAP CSI Driver add-on"
+  type        = bool
+  default     = false
+}
+
+variable "enable_fsxn_csi_driver_gitops" {
+  description = "Enable FSX NETAPP ONTAP CSI Driver using GitOps add-on"
+  type        = bool
+  default     = false
+}
+
+variable "fsxn_csi_driver" {
+  description = "FSX NETAPP ONTAP CSI Driver addon configuration values"
+  type        = any
+  default     = {}
+}
+
 #-----------AWS LB Ingress Controller-------------
 variable "enable_aws_load_balancer_controller" {
   description = "Enable AWS Load Balancer Controller add-on"


### PR DESCRIPTION
### What does this PR do?

This PR adds support for FSx for NetApp ONTAP CSI driver
- Added variables to support FSxN helm chart
- Added call to eks-bluerpints-addon module with input vars to install FSxN csi driver from helm chart


### Motivation

Customers that are working on EKS with Terraform and blueprints/EKS add-ons and implementing FSxN as storage would like to see an integrated way to deploy the CSI driver, same as EBS, EFS and FSx Lustre

### More

- [X ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
