### PR TITLE
fix: Fix InstanceProfile references in `locals` and `aws_iam_instance_profile.karpenter` resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1743,7 +1743,7 @@ locals {
   karpenter_service_account_name    = try(var.karpenter.service_account_name, "karpenter")
   karpenter_enable_spot_termination = var.enable_karpenter && var.karpenter_enable_spot_termination
   create_karpenter_instance_profile = try(var.karpenter_instance_profile.create, true)
-  karpenter_instance_profile_name   = try(aws_iam_instance_profile.karpenter[0].arn, var.karpenter_instance_profile.name, "")
+  karpenter_instance_profile_name   = try(aws_iam_instance_profile.karpenter[0].name, var.karpenter_instance_profile.name, "")
 }
 
 data "aws_iam_policy_document" "karpenter" {
@@ -1883,7 +1883,7 @@ resource "aws_iam_instance_profile" "karpenter" {
 
   name_prefix = try(var.karpenter_instance_profile.name_prefix, "karpenter-")
   path        = try(var.karpenter_instance_profile.path, null)
-  role        = var.karpenter_instance_profile.iam_role_arn
+  role        = var.karpenter_instance_profile.iam_role_name
 
   tags = merge(var.tags, try(var.karpenter_instance_profile.tags, {}))
 }


### PR DESCRIPTION
### What does this PR do?

Fix  references for the Karpenter InstanceProfile Name pointing to the RoleARN, other than the RoleName.

https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/main.tf#L1746
```hcl {#5}
locals {
  karpenter_service_account_name    = try(var.karpenter.service_account_name, "karpenter")
  karpenter_enable_spot_termination = var.enable_karpenter && var.karpenter_enable_spot_termination
  create_karpenter_instance_profile = try(var.karpenter_instance_profile.create, true)
  karpenter_instance_profile_name   = try(aws_iam_instance_profile.karpenter[0].name, var.karpenter_instance_profile.name, "")
}
```

https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/main.tf#L1886
```hcl {#6}
resource "aws_iam_instance_profile" "karpenter" {
  count = var.enable_karpenter && local.create_karpenter_instance_profile ? 1 : 0

  name_prefix = try(var.karpenter_instance_profile.name_prefix, "karpenter-")
  path        = try(var.karpenter_instance_profile.path, null)
  role        = var.karpenter_instance_profile.iam_role_name

  tags = merge(var.tags, try(var.karpenter_instance_profile.tags, {}))
}
```

### Motivation

- Resolves #129 

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

```bash
terraform-aws-eks-blueprints-addons git:(fix/karpenter) ✗ pre-commit run -a                      
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for merge conflicts................................................Passed
detect private key.......................................................Passed
detect aws credentials...................................................Passed
Terraform fmt............................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
Terraform validate.......................................................Passed
Terraform validate with tfsec............................................Passed
```