### PR TITLE
fix: Use correct keys for serviceAccount name for alb chart

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1376,7 +1376,7 @@ module "aws_load_balancer_controller" {
   postrender = try(var.aws_load_balancer_controller.postrender, [])
   set = concat([
     {
-      name  = "controller.serviceAccount.name"
+      name  = "serviceAccount.name"
       value = local.aws_load_balancer_controller_service_account
       }, {
       name  = "clusterName"
@@ -2376,7 +2376,7 @@ module "ingress_nginx" {
   name             = try(var.ingress_nginx.name, local.ingress_nginx_name)
   description      = try(var.ingress_nginx.description, "A Helm chart to install the Ingress Nginx")
   namespace        = try(var.ingress_nginx.namespace, "ingress-nginx")
-  create_namespace = try(var.ingress_nginx.create_namespace, false)
+  create_namespace = try(var.ingress_nginx.create_namespace, true)
   chart            = local.ingress_nginx_name
   chart_version    = try(var.ingress_nginx.chart_version, "4.6.0")
   repository       = try(var.ingress_nginx.repository, "https://kubernetes.github.io/ingress-nginx")


### PR DESCRIPTION
### What does this PR do?

1. Uses the correct field when setting the name of the serviceAccountName for the AWS Load Balancer Controller helm chart.
2. Fixes another minor bug in ingress-nginx where we did not create namespace by default.

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #133

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
