### PR TITLE
fix: Ensure `karpenter` and `velero` resources are not created when they are not enabled

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.3
+    rev: v1.78.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/main.tf
+++ b/main.tf
@@ -2258,7 +2258,7 @@ locals {
 
 data "aws_iam_role" "karpenter" {
   count = var.enable_karpenter ? 1 : 0
-  name = var.karpenter_instance_profile.iam_role_name
+  name  = var.karpenter_instance_profile.iam_role_name
 }
 
 data "aws_iam_policy_document" "karpenter" {

--- a/main.tf
+++ b/main.tf
@@ -2257,6 +2257,7 @@ locals {
 }
 
 data "aws_iam_role" "karpenter" {
+  count = var.enable_karpenter ? 1 : 0
   name = var.karpenter_instance_profile.iam_role_name
 }
 
@@ -2294,7 +2295,7 @@ data "aws_iam_policy_document" "karpenter" {
 
   statement {
     actions   = ["iam:PassRole"]
-    resources = [data.aws_iam_role.karpenter.arn]
+    resources = [data.aws_iam_role.karpenter.0.arn]
   }
 
   statement {
@@ -2744,9 +2745,9 @@ module "secrets_store_csi_driver_provider_aws" {
 locals {
   velero_name                    = "velero"
   velero_service_account         = try(var.velero.service_account_name, "${local.velero_name}-server")
-  velero_backup_s3_bucket        = split(":", var.velero.s3_backup_location)
-  velero_backup_s3_bucket_arn    = try(split("/", var.velero.s3_backup_location)[0], var.velero.s3_backup_location)
-  velero_backup_s3_bucket_name   = try(split("/", local.velero_backup_s3_bucket[5])[0], local.velero_backup_s3_bucket[5])
+  velero_backup_s3_bucket        = try(split(":", var.velero.s3_backup_location), [])
+  velero_backup_s3_bucket_arn    = try(split("/", var.velero.s3_backup_location)[0], var.velero.s3_backup_location, "")
+  velero_backup_s3_bucket_name   = try(split("/", local.velero_backup_s3_bucket[5])[0], local.velero_backup_s3_bucket[5], "")
   velero_backup_s3_bucket_prefix = try(split("/", var.velero.s3_backup_location)[1], "")
 }
 

--- a/main.tf
+++ b/main.tf
@@ -2295,7 +2295,7 @@ data "aws_iam_policy_document" "karpenter" {
 
   statement {
     actions   = ["iam:PassRole"]
-    resources = [data.aws_iam_role.karpenter.0.arn]
+    resources = [data.aws_iam_role.karpenter[0].arn]
   }
 
   statement {


### PR DESCRIPTION
### What does this PR do?

To resolve [apply failed when not enable Karpenter and/or Velero](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/issues/148).

### Motivation

Create and use the data resource only when enable_karpenter is false.

Update Velero local variables to accept empty string when enable_velero is false.

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Executed `terraform plan` with success using the [test](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/tests/complete/README.md).