### PR TITLE
feat: Add outputs for AWS resources created for `karpetner` and `aws-node-termination-handler`

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -40,7 +40,12 @@ output "aws_load_balancer_controller" {
 
 output "aws_node_termination_handler" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.aws_node_termination_handler
+  value = merge(
+    module.aws_node_termination_handler,
+    {
+      sqs = module.aws_node_termination_handler_sqs
+    }
+  )
 }
 
 output "aws_privateca_issuer" {
@@ -95,7 +100,13 @@ output "ingress_nginx" {
 
 output "karpenter" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.karpenter
+  value = merge(
+    module.karpenter,
+    {
+      iam_instance_profile_name = local.karpenter_instance_profile_name
+      sqs                       = module.karpenter_sqs
+    }
+  )
 }
 
 output "kube_prometheus_stack" {


### PR DESCRIPTION
### What does this PR do?

- Add outputs for AWS resources created for `karpetner` and `aws-node-termination-handler`

### Motivation

- These are necessary to pass to relevant resources, such as the Karpenter provisioner template

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
