### PR TITLE
chore: Bump add-on versions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2710,7 +2710,7 @@ module "secrets_store_csi_driver" {
   namespace        = try(var.secrets_store_csi_driver.namespace, "kube-system")
   create_namespace = try(var.secrets_store_csi_driver.create_namespace, false)
   chart            = "secrets-store-csi-driver"
-  chart_version    = try(var.secrets_store_csi_driver.chart_version, "1.3.2")
+  chart_version    = try(var.secrets_store_csi_driver.chart_version, "1.3.3")
   repository       = try(var.secrets_store_csi_driver.repository, "https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts")
   values           = try(var.secrets_store_csi_driver.values, [])
 
@@ -2751,17 +2751,13 @@ module "secrets_store_csi_driver" {
 # Secrets Store CSI Driver Provider AWS
 ################################################################################
 
-locals {
-  secrets_store_csi_driver_provider_aws_service_account = try(var.secrets_store_csi_driver_provider_aws.service_account_name, "secrets-store-csi-driver-provider-aws-sa")
-}
-
 module "secrets_store_csi_driver_provider_aws" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.0.0"
 
   create = var.enable_secrets_store_csi_driver_provider_aws
 
-  # https://github.com/aws/eks-charts/blob/master/stable/csi-secrets-store-provider-aws/Chart.yaml
+  # https://github.com/aws/secrets-store-csi-driver-provider-aws/blob/main/charts/secrets-store-csi-driver-provider-aws/Chart.yaml
   name             = try(var.secrets_store_csi_driver_provider_aws.name, "secrets-store-csi-driver-provider-aws")
   description      = try(var.secrets_store_csi_driver_provider_aws.description, "A Helm chart to install the Secrets Store CSI Driver and the AWS Key Management Service Provider inside a Kubernetes cluster.")
   namespace        = try(var.secrets_store_csi_driver_provider_aws.namespace, "kube-system")
@@ -2797,14 +2793,8 @@ module "secrets_store_csi_driver_provider_aws" {
   replace                    = try(var.secrets_store_csi_driver_provider_aws.replace, null)
   lint                       = try(var.secrets_store_csi_driver_provider_aws.lint, null)
 
-  postrender = try(var.secrets_store_csi_driver_provider_aws.postrender, [])
-  set = concat([
-    {
-      name  = "serviceAccount.name"
-      value = local.secrets_store_csi_driver_provider_aws_service_account
-    }],
-    try(var.secrets_store_csi_driver_provider_aws.set, [])
-  )
+  postrender    = try(var.secrets_store_csi_driver_provider_aws.postrender, [])
+  set           = try(var.secrets_store_csi_driver_provider_aws.set, [])
   set_sensitive = try(var.secrets_store_csi_driver_provider_aws.set_sensitive, [])
 
   tags = var.tags
@@ -3003,7 +2993,7 @@ module "vpa" {
   namespace        = try(var.vpa.namespace, "vpa")
   create_namespace = try(var.vpa.create_namespace, true)
   chart            = "vpa"
-  chart_version    = try(var.vpa.chart_version, "1.7.2")
+  chart_version    = try(var.vpa.chart_version, "1.7.5")
   repository       = try(var.vpa.repository, "https://charts.fairwinds.com/stable")
   values           = try(var.vpa.values, [])
 
@@ -3033,8 +3023,14 @@ module "vpa" {
   replace                    = try(var.vpa.replace, null)
   lint                       = try(var.vpa.lint, null)
 
-  postrender    = try(var.vpa.postrender, [])
-  set           = try(var.vpa.set, [])
+  postrender = try(var.vpa.postrender, [])
+  set = concat([
+    {
+      name  = "admissionController.enabled"
+      value = true
+    }],
+    try(var.vpa.set, [])
+  )
   set_sensitive = try(var.vpa.set_sensitive, [])
 
   tags = var.tags

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -63,13 +63,40 @@ module "eks" {
   version = "~> 19.13"
 
   cluster_name                   = local.name
-  cluster_version                = "1.25"
+  cluster_version                = "1.26"
   cluster_endpoint_public_access = true
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 
   manage_aws_auth_configmap = true
+
+  cluster_addons = {
+    aws-ebs-csi-driver = {
+      most_recent              = true
+      service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
+    }
+    coredns = {
+      preserve    = true
+      most_recent = true
+
+      timeouts = {
+        create = "25m"
+        delete = "10m"
+      }
+    }
+    vpc-cni = {
+      most_recent              = true
+      service_account_role_arn = module.vpc_cni_irsa.iam_role_arn
+    }
+    kube-proxy = {}
+    # ADOT has a dependency on cert-manager.
+    #adot = {
+    #  most_recent              = true
+    #  service_account_role_arn = module.adot_irsa.iam_role_arn
+    #}
+    aws-guardduty-agent = {}
+  }
 
   eks_managed_node_groups = {
     initial = {
@@ -106,31 +133,6 @@ module "eks_blueprints_addons" {
   cluster_version   = module.eks.cluster_version
   oidc_provider_arn = module.eks.oidc_provider_arn
 
-  eks_addons = {
-    aws-ebs-csi-driver = {
-      most_recent              = true
-      service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
-    }
-    coredns = {
-      preserve    = true
-      most_recent = true
-    }
-    vpc-cni = {
-      most_recent              = true
-      service_account_role_arn = module.vpc_cni_irsa.iam_role_arn
-    }
-    kube-proxy = {
-      most_recent = true
-    }
-    adot = {
-      most_recent              = true
-      service_account_role_arn = module.adot_irsa.iam_role_arn
-    }
-    aws-guardduty-agent = {
-      most_recent = true
-    }
-  }
-
   enable_aws_efs_csi_driver                    = true
   enable_aws_fsx_csi_driver                    = true
   enable_argocd                                = true
@@ -162,7 +164,7 @@ module "eks_blueprints_addons" {
   }
 
   enable_velero = true
-  # An S3 Bucket ARN is required. This can be declared with or without a Prefix.
+  ## An S3 Bucket ARN is required. This can be declared with or without a Prefix.
   velero = {
     s3_backup_location = "${module.velero_backup_s3_bucket.s3_bucket_arn}/backups"
   }

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -77,7 +77,6 @@ module "eks" {
       service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
     }
     coredns = {
-      preserve    = true
       most_recent = true
 
       timeouts = {


### PR DESCRIPTION
### What does this PR do?

Bumps some add-on versions and add update default behavior of VPA to run the admission controller without which it is pretty much useless.

Moved EKS addons to EKS module to use cluster_addons, this makes terraform destroy of addons module less buggy.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [x] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
