### PR TITLE
chore: Bump aws-cloudwatch-metrics version to v0.0.9

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -245,7 +245,7 @@ module "aws_cloudwatch_metrics" {
   namespace        = try(var.aws_cloudwatch_metrics.namespace, "amazon-cloudwatch")
   create_namespace = try(var.aws_cloudwatch_metrics.create_namespace, true)
   chart            = "aws-cloudwatch-metrics"
-  chart_version    = try(var.aws_cloudwatch_metrics.chart_version, "0.0.8")
+  chart_version    = try(var.aws_cloudwatch_metrics.chart_version, "0.0.9")
   repository       = try(var.aws_cloudwatch_metrics.repository, "https://aws.github.io/eks-charts")
   values           = try(var.aws_cloudwatch_metrics.values, [])
 


### PR DESCRIPTION
### What does this PR do?

Bump version of aws-cloudwatch-metrics module

### Motivation

Found it while testing

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
