### PR TITLE
chore: Removing old comments that reference deprecated external-secrets project

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1833,7 +1833,6 @@ locals {
   external_dns_service_account = try(var.external_dns.service_account_name, "external-dns-sa")
 }
 
-# https://github.com/external-secrets/kubernetes-external-secrets#add-a-secret
 data "aws_iam_policy_document" "external_dns" {
   count = var.enable_external_dns && length(var.external_dns_route53_zone_arns) > 0 ? 1 : 0
 
@@ -1943,7 +1942,6 @@ locals {
   external_secrets_service_account = try(var.external_secrets.service_account_name, "external-secrets-sa")
 }
 
-# https://github.com/external-secrets/kubernetes-external-secrets#add-a-secret
 data "aws_iam_policy_document" "external_secrets" {
   count = var.enable_external_secrets ? 1 : 0
 


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

Removing old comments that point to deprecated external-secrets project

### Motivation

I like clean things

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
