### PR TITLE
chore: Ensure docs CI runs if any CI configurations are made

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -4,9 +4,10 @@ on:
     branches:
       - main
     paths:
-      - "docs/**"
-      - "mkdocs.yml"
+      - 'docs/**'
+      - mkdocs.yml
       - README.md
+      - '.github/workflows/publish-docs.yaml'
 
   release:
     types:


### PR DESCRIPTION
### What does this PR do?

- Ensure docs CI runs if any CI configurations are made

### Motivation

- Trigger new doc publish

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
