### PR TITLE
feat: Add generic `helm_releases` variable for provisioning any number of Helm charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Please note: not all addons will be supported as they are today in the main EKS 
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.47 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.9 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.20 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
 
@@ -23,6 +24,7 @@ Please note: not all addons will be supported as they are today in the main EKS 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.47 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.9 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.20 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.9 |
 
@@ -75,6 +77,7 @@ Please note: not all addons will be supported as they are today in the main EKS 
 | [aws_iam_role.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_config_map_v1.aws_logging](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1) | resource |
 | [kubernetes_namespace_v1.aws_observability](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 | [time_sleep.this](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
@@ -159,6 +162,7 @@ Please note: not all addons will be supported as they are today in the main EKS 
 | <a name="input_fargate_fluentbit"></a> [fargate\_fluentbit](#input\_fargate\_fluentbit) | Fargate fluentbit add-on config | `any` | `{}` | no |
 | <a name="input_fargate_fluentbit_cw_log_group"></a> [fargate\_fluentbit\_cw\_log\_group](#input\_fargate\_fluentbit\_cw\_log\_group) | AWS Fargate Fluentbit CloudWatch Log Group configurations | `any` | `{}` | no |
 | <a name="input_gatekeeper"></a> [gatekeeper](#input\_gatekeeper) | Gatekeeper add-on configuration | `any` | `{}` | no |
+| <a name="input_helm_releases"></a> [helm\_releases](#input\_helm\_releases) | A map of Helm releases to create. This provides the ability to pass in an arbitrary map of Helm chart definitions to create | `any` | `{}` | no |
 | <a name="input_ingress_nginx"></a> [ingress\_nginx](#input\_ingress\_nginx) | Ingress Nginx add-on configurations | `any` | `{}` | no |
 | <a name="input_karpenter"></a> [karpenter](#input\_karpenter) | Karpenter addon configuration values | `any` | `{}` | no |
 | <a name="input_karpenter_enable_spot_termination"></a> [karpenter\_enable\_spot\_termination](#input\_karpenter\_enable\_spot\_termination) | Determines whether to enable native node termination handling | `bool` | `true` | no |
@@ -195,6 +199,7 @@ Please note: not all addons will be supported as they are today in the main EKS 
 | <a name="output_external_secrets"></a> [external\_secrets](#output\_external\_secrets) | Map of attributes of the Helm release and IRSA created |
 | <a name="output_fargate_fluentbit"></a> [fargate\_fluentbit](#output\_fargate\_fluentbit) | Map of attributes of the configmap and IAM policy created |
 | <a name="output_gatekeeper"></a> [gatekeeper](#output\_gatekeeper) | Map of attributes of the Helm release and IRSA created |
+| <a name="output_helm_releases"></a> [helm\_releases](#output\_helm\_releases) | Map of attributes of the Helm release created |
 | <a name="output_ingress_nginx"></a> [ingress\_nginx](#output\_ingress\_nginx) | Map of attributes of the Helm release and IRSA created |
 | <a name="output_karpenter"></a> [karpenter](#output\_karpenter) | Map of attributes of the Helm release and IRSA created |
 | <a name="output_kube_prometheus_stack"></a> [kube\_prometheus\_stack](#output\_kube\_prometheus\_stack) | Map of attributes of the Helm release and IRSA created |

--- a/helm.tf
+++ b/helm.tf
@@ -1,0 +1,71 @@
+################################################################################
+# (Generic) Helm Release
+################################################################################
+
+resource "helm_release" "this" {
+  for_each = var.helm_releases
+
+  name             = try(each.value.name, each.key)
+  description      = try(each.value.description, null)
+  namespace        = try(each.value.namespace, null)
+  create_namespace = try(each.value.create_namespace, null)
+  chart            = each.value.chart
+  version          = try(each.value.chart_version, null)
+  repository       = try(each.value.repository, null)
+  values           = try(each.value.values, [])
+
+  timeout                    = try(each.value.timeout, null)
+  repository_key_file        = try(each.value.repository_key_file, null)
+  repository_cert_file       = try(each.value.repository_cert_file, null)
+  repository_ca_file         = try(each.value.repository_ca_file, null)
+  repository_username        = try(each.value.repository_username, null)
+  repository_password        = try(each.value.repository_password, null)
+  devel                      = try(each.value.devel, null)
+  verify                     = try(each.value.verify, null)
+  keyring                    = try(each.value.keyring, null)
+  disable_webhooks           = try(each.value.disable_webhooks, null)
+  reuse_values               = try(each.value.reuse_values, null)
+  reset_values               = try(each.value.reset_values, null)
+  force_update               = try(each.value.force_update, null)
+  recreate_pods              = try(each.value.recreate_pods, null)
+  cleanup_on_fail            = try(each.value.cleanup_on_fail, null)
+  max_history                = try(each.value.max_history, null)
+  atomic                     = try(each.value.atomic, null)
+  skip_crds                  = try(each.value.skip_crds, null)
+  render_subchart_notes      = try(each.value.render_subchart_notes, null)
+  disable_openapi_validation = try(each.value.disable_openapi_validation, null)
+  wait                       = try(each.value.wait, null)
+  wait_for_jobs              = try(each.value.wait_for_jobs, null)
+  dependency_update          = try(each.value.dependency_update, null)
+  replace                    = try(each.value.replace, null)
+  lint                       = try(each.value.lint, null)
+
+  dynamic "postrender" {
+    for_each = try([each.value.postrender], [])
+
+    content {
+      binary_path = postrender.value.binary_path
+      args        = try(postrender.value.args, null)
+    }
+  }
+
+  dynamic "set" {
+    for_each = try(each.value.set, [])
+
+    content {
+      name  = set.value.name
+      value = set.value.value
+      type  = try(set.value.type, null)
+    }
+  }
+
+  dynamic "set_sensitive" {
+    for_each = try(each.value.set_sensitive, [])
+
+    content {
+      name  = set_sensitive.value.name
+      value = set_sensitive.value.value
+      type  = try(set_sensitive.value.type, null)
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -142,3 +142,12 @@ output "vpa" {
   description = "Map of attributes of the Helm release and IRSA created"
   value       = module.vpa
 }
+
+################################################################################
+# (Generic) Helm Release
+################################################################################
+
+output "helm_releases" {
+  description = "Map of attributes of the Helm release created"
+  value       = helm_release.this
+}

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -103,7 +103,7 @@ module "eks" {
 
       min_size     = 2
       max_size     = 10
-      desired_size = 2
+      desired_size = 3
     }
   }
 
@@ -111,9 +111,9 @@ module "eks" {
     default = {
       instance_type = "m5.large"
 
-      min_size     = 1
-      max_size     = 3
-      desired_size = 1
+      min_size     = 2
+      max_size     = 10
+      desired_size = 3
     }
   }
 
@@ -187,10 +187,10 @@ module "eks_blueprints_addons" {
     }
     gpu-operator = {
       description      = "A Helm chart for NVIDIA GPU operator"
-      namespace        = "nvidia/gpu-operator"
+      namespace        = "gpu-operator"
       create_namespace = true
       chart            = "gpu-operator"
-      chart_version    = "23.2.2"
+      chart_version    = "v23.3.2"
       repository       = "https://nvidia.github.io/gpu-operator"
       values = [
         <<-EOT

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -168,6 +168,39 @@ module "eks_blueprints_addons" {
     s3_backup_location = "${module.velero_backup_s3_bucket.s3_bucket_arn}/backups"
   }
 
+  # Pass in any number of Helm charts to be created for those that are not natively supported
+  helm_releases = {
+    prometheus-adapter = {
+      description      = "A Helm chart for k8s prometheus adapter"
+      namespace        = "prometheus-adapter"
+      create_namespace = true
+      chart            = "prometheus-adapter"
+      chart_version    = "4.2.0"
+      repository       = "https://prometheus-community.github.io/helm-charts"
+      values = [
+        <<-EOT
+          replicas: 2
+          podDisruptionBudget:
+            enabled: true
+        EOT
+      ]
+    }
+    gpu-operator = {
+      description      = "A Helm chart for NVIDIA GPU operator"
+      namespace        = "nvidia/gpu-operator"
+      create_namespace = true
+      chart            = "gpu-operator"
+      chart_version    = "23.2.2"
+      repository       = "https://nvidia.github.io/gpu-operator"
+      values = [
+        <<-EOT
+          operator:
+            defaultRuntime: containerd
+        EOT
+      ]
+    }
+  }
+
   tags = local.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,16 @@ variable "create_delay_dependencies" {
 }
 
 ################################################################################
+# (Generic) Helm Release
+################################################################################
+
+variable "helm_releases" {
+  description = "A map of Helm releases to create. This provides the ability to pass in an arbitrary map of Helm chart definitions to create"
+  type        = any
+  default     = {}
+}
+
+################################################################################
 # Argo Rollouts
 ################################################################################
 

--- a/versions.tf
+++ b/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.47"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.9"
+    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = ">= 2.20"


### PR DESCRIPTION
### What does this PR do?

- Add generic `helm_releases` variable for provisioning any number of Helm charts

### Motivation

- This addition supports creating an arbitrary number of Helm chart releases which gives users the ability to supplement the module definition with additional Helm charts if not natively supported by the module
- Resolves #168
- Resolves #154
- Resoles #97
- Resolves #47
- Resolves #46

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
