### PR TITLE
feat: Update AWS provider min required version to 5.0 to support new EKS addon arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ module "eks_blueprints_addons" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.47 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.9 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.20 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
@@ -70,7 +70,7 @@ module "eks_blueprints_addons" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.47 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.9 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.20 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.9 |

--- a/docs/amazon-eks-addons.md
+++ b/docs/amazon-eks-addons.md
@@ -1,0 +1,200 @@
+# Amazon EKS add-ons
+
+The Amazon EKS add-on implementation is generic and can be used to deploy any add-on supported by the EKS API; either native EKS addons or third party add-ons supplied via the AWS Marketplace.
+
+See the [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html) for more details on EKS addon-ons, including the list of [Amazon EKS add-ons from Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html#workloads-add-ons-available-eks), as well as [Additional Amazon EKS add-ons from independent software vendors](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html#workloads-add-ons-available-vendors).
+
+## Architecture Support
+
+The Amazon EKS provided add-ons listed below support both `x86_64/amd64` and `arm64` architectures. Third party add-ons that are available via the AWS Marketplace will vary based on the support provided by the add-on vendor. No additional changes are required to add-on configurations when switching between `x86_64/amd64` and `arm64` architectures; Amazon EKS add-ons utilize multi-architecture container images to support this functionality.
+
+| Add-on | x86_64/amd64 | arm64 |
+|-------|:------:|:-----:|
+| `vpc-cni` | ✅ | ✅ |
+| `aws-ebs-csi-driver` | ✅ | ✅ |
+| `coredns` | ✅ | ✅ |
+| `kube-proxy` | ✅ | ✅ |
+| `adot` | ✅ | ✅ |
+| `aws-guardduty-agent` | ✅ | ✅ |
+
+## Usage
+
+The Amazon EKS add-ons are provisioned via a generic interface behind the `eks_addons` argument which accepts a map of add-on configurations. The generic interface for an add-on is defined below for reference:
+
+```hcl
+module "eks_blueprints_addons" {
+  source = "aws-ia/eks-blueprints-addons/aws"
+
+  # ... truncated for brevity
+
+  eks_addons = {
+    <key> = {
+      name = string # Optional - <key> is used if `name` is not set
+
+      most_recent          = bool
+      addon_version        = string # overrides `most_recent` if set
+      configuration_values = string # JSON string
+
+      preserve                    = bool # defaults to `true`
+      resolve_conflicts_on_create = string # defaults to `OVERWRITE`
+      resolve_conflicts_on_update = string # defaults to `OVERWRITE`
+
+      timeouts = {
+        create = string # optional
+        update = string # optional
+        delete = string # optional
+      }
+
+      tags = map(string)
+    }
+  }
+}
+```
+
+### Example
+
+```hcl
+module "eks_blueprints_addons" {
+  source = "aws-ia/eks-blueprints-addons/aws"
+
+  # ... truncated for brevity
+
+  eks_addons = {
+    # Amazon EKS add-ons
+    aws-ebs-csi-driver = {
+      most_recent              = true
+      service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
+    }
+
+    coredns = {
+      most_recent = true
+
+      timeouts = {
+        create = "25m"
+        delete = "10m"
+      }
+    }
+
+    vpc-cni = {
+      most_recent              = true
+      service_account_role_arn = module.vpc_cni_irsa.iam_role_arn
+    }
+
+    kube-proxy = {}
+
+    # Third party add-ons via AWS Marketplace
+    kubecost_kubecost = {
+      most_recent = true
+    }
+
+    teleport_teleport = {
+      most_recent = true
+    }
+  }
+}
+```
+
+### Configuration Values
+
+You can supply custom configuration values to each addon via the `configuration_values` argument of the add-on definition. The value provided must be a JSON encoded string and adhere to the JSON scheme provided by the version of the add-on. You can view this schema using the awscli by supplying the add-on name and version to the `describe-addon-configuration` command:
+
+```sh
+aws eks describe-addon-configuration \
+ --addon-name coredns \
+ --addon-version v1.8.7-eksbuild.2 \
+ --query 'configurationSchema' \
+ --output text | jq
+```
+
+Which returns the formatted JSON schema like below:
+
+```json
+{
+  "$ref": "#/definitions/Coredns",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "definitions": {
+    "Coredns": {
+      "additionalProperties": false,
+      "properties": {
+        "computeType": {
+          "type": "string"
+        },
+        "corefile": {
+          "description": "Entire corefile contents to use with installation",
+          "type": "string"
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "replicaCount": {
+          "type": "integer"
+        },
+        "resources": {
+          "$ref": "#/definitions/Resources"
+        }
+      },
+      "title": "Coredns",
+      "type": "object"
+    },
+    "Limits": {
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "type": "string"
+        },
+        "memory": {
+          "type": "string"
+        }
+      },
+      "title": "Limits",
+      "type": "object"
+    },
+    "Resources": {
+      "additionalProperties": false,
+      "properties": {
+        "limits": {
+          "$ref": "#/definitions/Limits"
+        },
+        "requests": {
+          "$ref": "#/definitions/Limits"
+        }
+      },
+      "title": "Resources",
+      "type": "object"
+    }
+  }
+}
+```
+
+You can supply the configuration values to the add-on by passing a map of the values wrapped in the `jsonencode()` function as shown below:
+
+```hcl
+module "eks_blueprints_addons" {
+  source = "aws-ia/eks-blueprints-addons/aws"
+
+  # ... truncated for brevity
+
+  eks_addons = {
+    coredns = {
+      most_recent = true
+
+      configuration_values = jsonencode({
+        replicaCount = 4
+        resources = {
+          limits = {
+            cpu    = "100m"
+            memory = "150Mi"
+          }
+          requests = {
+            cpu    = "100m"
+            memory = "150Mi"
+          }
+        }
+      })
+    }
+  }
+}
+```

--- a/docs/architectures.md
+++ b/docs/architectures.md
@@ -29,7 +29,7 @@
 
 ## [Amazon EKS Addons](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html)
 
-Only the EKS provided addons are listed below; 3rd party addons that are available via the AWS Marketplace will vary based on the support provided by the addon vendor. These addons are specified via the `eks_addons` input variable.
+The Amazon EKS provided add-ons listed below support both `x86_64/amd64` and `arm64` architectures. Third party add-ons that are available via the AWS Marketplace will vary based on the support provided by the add-on vendor. No additional changes are required to add-on configurations when switching between `x86_64/amd64` and `arm64` architectures; Amazon EKS add-ons utilize multi-architecture container images to support this functionality. These addons are specified via the `eks_addons` input variable.
 
 | Addon | x86_64/amd64 | arm64 |
 |-------|:------:|:-----:|

--- a/docs/aws-private-ca-issuer.md
+++ b/docs/aws-private-ca-issuer.md
@@ -1,6 +1,6 @@
 # AWS Private CA (PCA) Issuer
 
-[AWS Private CA](https://aws.amazon.com/private-ca/) is an AWS service that can setup and manage private CAs, as well as issue private certifiates. This Add-on deployes the AWS Private CA Issuer as an [external issuer](https://cert-manager.io/docs/configuration/external/) to **cert-manager** that signs off certificate requests using AWS Private CA in an Amazon EKS Cluster.
+[AWS Private CA](https://aws.amazon.com/private-ca/) is an AWS service that can setup and manage private CAs, as well as issue private certificates. This add-on deploys the AWS Private CA Issuer as an [external issuer](https://cert-manager.io/docs/configuration/external/) to **cert-manager** that signs off certificate requests using AWS Private CA in an Amazon EKS Cluster.
 
 ## Usage
 

--- a/main.tf
+++ b/main.tf
@@ -1805,11 +1805,12 @@ resource "aws_eks_addon" "this" {
   cluster_name = local.cluster_name
   addon_name   = try(each.value.name, each.key)
 
-  addon_version            = try(each.value.addon_version, data.aws_eks_addon_version.this[each.key].version)
-  configuration_values     = try(each.value.configuration_values, null)
-  preserve                 = try(each.value.preserve, null)
-  resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
-  service_account_role_arn = try(each.value.service_account_role_arn, null)
+  addon_version               = try(each.value.addon_version, data.aws_eks_addon_version.this[each.key].version)
+  configuration_values        = try(each.value.configuration_values, null)
+  preserve                    = try(each.value.preserve, true)
+  resolve_conflicts_on_create = try(each.value.resolve_conflicts, "OVERWRITE")
+  resolve_conflicts_on_update = try(each.value.resolve_conflicts, "OVERWRITE")
+  service_account_role_arn    = try(each.value.service_account_role_arn, null)
 
   timeouts {
     create = try(each.value.timeouts.create, var.eks_addons_timeouts.create, null)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
   - Overview: index.md
   - Architectures: architectures.md
   - Addons:
+    - Amazon EKS Add-Ons: amazon-eks-addons.md
     - AWS CloudWatch Metrics: aws-cloudwatch-metrics.md
     - AWS EFS CSI Driver: aws-efs-csi-driver.md
     - AWS FSx CSI Driver: aws-fsx-csi-driver.md

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -85,8 +85,7 @@ module "eks" {
       }
     }
     vpc-cni = {
-      most_recent              = true
-      service_account_role_arn = module.vpc_cni_irsa.iam_role_arn
+      most_recent = true
     }
     kube-proxy = {}
     # ADOT has a dependency on cert-manager.
@@ -144,13 +143,13 @@ module "eks_blueprints_addons" {
   enable_kube_prometheus_stack                 = true
   enable_external_dns                          = true
   enable_external_secrets                      = true
-  enable_gatekeeper                            = true
-  enable_ingress_nginx                         = true
-  enable_aws_load_balancer_controller          = true
-  enable_metrics_server                        = true
-  enable_vpa                                   = true
-  enable_aws_for_fluentbit                     = true
-  enable_fargate_fluentbit                     = true
+  # enable_gatekeeper                            = true
+  enable_ingress_nginx                = true
+  enable_aws_load_balancer_controller = true
+  enable_metrics_server               = true
+  enable_vpa                          = true
+  enable_aws_for_fluentbit            = true
+  enable_fargate_fluentbit            = true
 
   enable_aws_node_termination_handler   = true
   aws_node_termination_handler_asg_arns = [for asg in module.eks.self_managed_node_groups : asg.autoscaling_group_arn]
@@ -284,25 +283,6 @@ module "ebs_csi_driver_irsa" {
     main = {
       provider_arn               = module.eks.oidc_provider_arn
       namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
-    }
-  }
-
-  tags = local.tags
-}
-
-module "vpc_cni_irsa" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.14"
-
-  role_name_prefix = "${local.name}-vpc-cni-"
-
-  attach_vpc_cni_policy = true
-  vpc_cni_enable_ipv4   = true
-
-  oidc_providers = {
-    main = {
-      provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["kube-system:aws-node"]
     }
   }
 

--- a/tests/complete/versions.tf
+++ b/tests/complete/versions.tf
@@ -6,20 +6,13 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.47"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.17"
-    }
     helm = {
       source  = "hashicorp/helm"
       version = ">= 2.8"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.20"
+    }
   }
-
-  # ##  Used for end-to-end testing on project; update to suit your needs
-  # backend "s3" {
-  #   bucket = "terraform-ssp-github-actions-state"
-  #   region = "us-west-2"
-  #   key    = "e2e/addons/complete/terraform.tfstate"
-  # }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.0"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
### What does this PR do?

- Update AWS provider min required version to 5.0 to support new EKS addon arguments

### Motivation

- Updates AWS provider to current version, replacing the deprecated argument  `resolve_conflicts` with `resolve_conflicts_on_create` and `resolve_conflicts_on_update`

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
