### PR TITLE
Fix(argo-wf): updating version to the latest existing one

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -134,7 +134,7 @@ module "argo_workflows" {
   namespace        = try(var.argo_workflows.namespace, "argo-workflows")
   create_namespace = try(var.argo_workflows.create_namespace, true)
   chart            = "argo-workflows"
-  chart_version    = try(var.argo_workflows.chart_version, "2.22.13")
+  chart_version    = try(var.argo_workflows.chart_version, "0.28.2")
   repository       = try(var.argo_workflows.repository, "https://argoproj.github.io/argo-helm")
   values           = try(var.argo_workflows.values, [])
 


### PR DESCRIPTION
### What does this PR do?

This PR updates the version to the latest existing one.

## Motivation

Argo-wf version does not exist, seems like it was copied from argo-rollouts. 