### PR TITLE
feat: Bump aws_load_balancer_controller version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1061,7 +1061,7 @@ module "aws_load_balancer_controller" {
   # namespace creation is false here as kube-system already exists by default
   create_namespace = try(var.aws_load_balancer_controller.create_namespace, false)
   chart            = "aws-load-balancer-controller"
-  chart_version    = try(var.aws_load_balancer_controller.chart_version, "1.4.8")
+  chart_version    = try(var.aws_load_balancer_controller.chart_version, "1.5.3")
   repository       = try(var.aws_load_balancer_controller.repository, "https://aws.github.io/eks-charts")
   values           = try(var.aws_load_balancer_controller.values, [])
 


### PR DESCRIPTION
### What does this PR do?

updates aws_load_balancer_controller version to latest available version from https://artifacthub.io/packages/helm/aws/aws-load-balancer-controller

### Motivation
I was using v4.32.1 blueprints and found that this add-on was outdated in v4 and doesn't work with v1.25 if EndpointSlices are used (https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.25). I updated it locally using
```
  enable_aws_load_balancer_controller = true
  aws_load_balancer_controller_helm_config = {
    version = "1.5.3"
  }
```

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Note that I have tested this with v4.32.1. But I think this should also work with v5 without any change. 
