### PR TITLE
fix: Fix AllowGetCertificates statement scope for ALB controller role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -948,8 +948,7 @@ data "aws_iam_policy_document" "aws_load_balancer_controller" {
     sid    = "AllowGetCertificates"
     effect = "Allow"
     resources = [
-      "arn:${local.partition}:acm:${local.region}:${local.account_id}:*",
-      "arn:${local.partition}:acm:${local.region}:${local.account_id}:certificate/*"
+      "*",
     ]
 
     actions = [


### PR DESCRIPTION
### What does this PR do?

This PR fixes the `AllowGetCertificates` statement in the IAM policy for ALB controller role.

The included IAM policy for ALB controller sets incorrect permissions for `AllowGetCertificates` statement. It prevents ALB controller from accessing ACM certificates and makes it impossible to use the certificate search functionality, resulting in errors like `AccessDeniedException: User: arn:aws:sts::433222222257:assumed-role/alb-controller-20230620120130875800000002/1687883887660094198 is not authorized to perform: acm:ListCertificates because no identity-based policy allows the acm:ListCertificates action"`

This is a result of limiting the statement to the following resources:

```
"arn:${local.partition}:acm:${local.region}:${local.account_id}:*",
"arn:${local.partition}:acm:${local.region}:${local.account_id}:certificate/*"
```

The actions do not take limits and only allow a wildcard (`"*"`) resource access.

Resolves #198 