### PR TITLE
feat: Add permissions for S3 write on FluentBit addons; add dependency on EKS addon for generic `helm_releases`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.80.0
+    rev: v1.81.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/helm.tf
+++ b/helm.tf
@@ -68,4 +68,9 @@ resource "helm_release" "this" {
       type  = try(set_sensitive.value.type, null)
     }
   }
+
+  depends_on = [
+    # Wait for EBS CSI, etc. to be installed first
+    aws_eks_addon.this,
+  ]
 }

--- a/tests/complete/README.md
+++ b/tests/complete/README.md
@@ -38,8 +38,8 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_adot_irsa"></a> [adot\_irsa](#module\_adot\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.14 |
-| <a name="module_ebs_csi_driver_irsa"></a> [ebs\_csi\_driver\_irsa](#module\_ebs\_csi\_driver\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.14 |
+| <a name="module_adot_irsa"></a> [adot\_irsa](#module\_adot\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.20 |
+| <a name="module_ebs_csi_driver_irsa"></a> [ebs\_csi\_driver\_irsa](#module\_ebs\_csi\_driver\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.20 |
 | <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 19.13 |
 | <a name="module_eks_blueprints_addons"></a> [eks\_blueprints\_addons](#module\_eks\_blueprints\_addons) | ../../ | n/a |
 | <a name="module_velero_backup_s3_bucket"></a> [velero\_backup\_s3\_bucket](#module\_velero\_backup\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -149,8 +149,14 @@ module "eks_blueprints_addons" {
   enable_aws_load_balancer_controller = true
   enable_metrics_server               = true
   enable_vpa                          = true
-  enable_aws_for_fluentbit            = true
   enable_fargate_fluentbit            = true
+  enable_aws_for_fluentbit            = true
+  aws_for_fluentbit = {
+    s3_bucket_arns = [
+      module.velero_backup_s3_bucket.s3_bucket_arn,
+      "${module.velero_backup_s3_bucket.s3_bucket_arn}/logs/*"
+    ]
+  }
 
   enable_aws_node_termination_handler   = true
   aws_node_termination_handler_asg_arns = [for asg in module.eks.self_managed_node_groups : asg.autoscaling_group_arn]
@@ -285,7 +291,7 @@ module "velero_backup_s3_bucket" {
 
 module "ebs_csi_driver_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.14"
+  version = "~> 5.20"
 
   role_name_prefix = "${local.name}-ebs-csi-driver-"
 
@@ -303,7 +309,7 @@ module "ebs_csi_driver_irsa" {
 
 module "adot_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.14"
+  version = "~> 5.20"
 
   role_name_prefix = "${local.name}-adot-"
 


### PR DESCRIPTION
### What does this PR do?

- Add permissions for S3 write on FluentBit addons; 
- Add dependency on EKS addon for generic `helm_releases`

### Motivation

- FluentBit supports writing to multiple locations including S3; this adds the permissions to send logs to S3 in addition to Cloudwatch (or not send to CloudWatch and only send to S3 - any combination)
- Since we deploy the EBS CSI driver in the EKS addons, and a number of helm charts require EBS CSI, I've added a dependency between these. I didn't go through and check our other addons, but potentially if they rely on EKS addons such as EBS CSI, then we can add the same dependency on them. This came up when deploying Weaviate using the generic `helm_releases` which requires EBS CSI and it failed since the CSI driver wasn't ready in time

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
