### PR TITLE
Use the local.region value to setup FluentBit #204

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -590,6 +590,34 @@ module "aws_for_fluentbit" {
     {
       name  = "serviceAccount.name"
       value = local.aws_for_fluentbit_service_account
+    },
+    {
+      name  = "cloudWatch.region"
+      value = local.region
+    },
+    {
+      name  = "cloudWatchLogs.region"
+      value = local.region
+    },
+    {
+      name  = "firehose.region"
+      value = local.region
+    },
+    {
+      name  = "kinesis.region"
+      value = local.region
+    },
+    {
+      name  = "elasticsearch.awsRegion"
+      value = local.region
+    },
+    {
+      name  = "s3.region"
+      value = local.region
+    },
+    {
+      name  = "opensearch.awsRegion"
+      value = local.region
     }],
     try(var.aws_for_fluentbit.set, [])
   )


### PR DESCRIPTION
### What does this PR do?

I added the set of variables that the FluentBit chart uses to override the hard coded value of `us-east-1` to the one the Terraform project might be using. Otherwise, the configuration might be pointing to the wrong region and logs won't be pushed correctly.

### Motivation

- Resolves #204

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
