### PR TITLE
fix: Set `helm_releases` default value for `wait` to `false`

### DIFF
--- a/helm.tf
+++ b/helm.tf
@@ -34,7 +34,7 @@ resource "helm_release" "this" {
   skip_crds                  = try(each.value.skip_crds, null)
   render_subchart_notes      = try(each.value.render_subchart_notes, null)
   disable_openapi_validation = try(each.value.disable_openapi_validation, null)
-  wait                       = try(each.value.wait, null)
+  wait                       = try(each.value.wait, false)
   wait_for_jobs              = try(each.value.wait_for_jobs, null)
   dependency_update          = try(each.value.dependency_update, null)
   replace                    = try(each.value.replace, null)


### PR DESCRIPTION
### What does this PR do?

- Set `helm_releases` default value for `wait` to `false`

### Motivation

- This is what we have for the other addons defined here so that we can avoid Terraform timeout errors and instead let the kubernetes controllers/operators resolve the deployment (eventually)

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
