### PR TITLE
fix: Disable policy data source if the associated addon is disabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -673,6 +673,8 @@ locals {
 }
 
 data "aws_iam_policy_document" "aws_fsx_csi_driver" {
+  create = var.enable_aws_fsx_csi_driver ? 1 : 0
+
   statement {
     sid       = "AllowCreateServiceLinkedRoles"
     resources = ["arn:${local.partition}:iam::*:role/aws-service-role/s3.data-source.lustre.fsx.${local.dns_suffix}/*"]
@@ -825,6 +827,8 @@ locals {
 }
 
 data "aws_iam_policy_document" "aws_load_balancer_controller" {
+  count = var.enable_aws_load_balancer_controller ? 1 : 0
+
   statement {
     sid       = "AllowCreateServiceLinkedRole"
     effect    = "Allow"

--- a/main.tf
+++ b/main.tf
@@ -673,7 +673,7 @@ locals {
 }
 
 data "aws_iam_policy_document" "aws_fsx_csi_driver" {
-  create = var.enable_aws_fsx_csi_driver ? 1 : 0
+  count = var.enable_aws_fsx_csi_driver ? 1 : 0
 
   statement {
     sid       = "AllowCreateServiceLinkedRoles"


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- No need to read policy if addon disabled

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
