### PR TITLE
docs: Add NetApp ONTAP Astra Trident CSI driver to partner addons

### DIFF
--- a/docs/aws-partner-addons.md
+++ b/docs/aws-partner-addons.md
@@ -4,6 +4,7 @@ The following addons are provided by [AWS Partners](https://aws.amazon.com/partn
 
 | Addon | Description |
 |-------|:------------|
+| [Amazon FSx for NetApp ONTAP CSI driver](https://github.com/NetApp/terraform-aws-netapp-fsxn-eks-addon) | NetApp's Astra Trident provides dynamic storage orchestration for FSx for NetApp ONTAP using a Container Storage Interface (CSI) compliant driver. |
 | [Ondat](https://github.com/ondat/terraform-eksblueprints-ondat-addon) | Ondat is a Kubernetes-native storage platform that enables stateful applications to run on Kubernetes. |
 | [Hashicorp - Consul](https://github.com/hashicorp/terraform-aws-hashicorp-consul-eks-addon) | Consul is a service networking solution to automate network configurations, discover services, and enable secure connectivity across any cloud or runtime. |
 | [Hashicorp - Vault](https://github.com/hashicorp/terraform-aws-hashicorp-vault-eks-addon) | Vault secures, stores, and tightly controls access to tokens, passwords, certificates, API keys, and other secrets in modern computing. |

--- a/docs/aws-partner-addons.md
+++ b/docs/aws-partner-addons.md
@@ -4,9 +4,9 @@ The following addons are provided by [AWS Partners](https://aws.amazon.com/partn
 
 | Addon | Description |
 |-------|:------------|
-| [Amazon FSx for NetApp ONTAP CSI driver](https://github.com/NetApp/terraform-aws-netapp-fsxn-eks-addon) | NetApp's Astra Trident provides dynamic storage orchestration for FSx for NetApp ONTAP using a Container Storage Interface (CSI) compliant driver. |
 | [Ondat](https://github.com/ondat/terraform-eksblueprints-ondat-addon) | Ondat is a Kubernetes-native storage platform that enables stateful applications to run on Kubernetes. |
 | [Hashicorp - Consul](https://github.com/hashicorp/terraform-aws-hashicorp-consul-eks-addon) | Consul is a service networking solution to automate network configurations, discover services, and enable secure connectivity across any cloud or runtime. |
 | [Hashicorp - Vault](https://github.com/hashicorp/terraform-aws-hashicorp-vault-eks-addon) | Vault secures, stores, and tightly controls access to tokens, passwords, certificates, API keys, and other secrets in modern computing. |
 | [Sysdig](https://github.com/sysdiglabs/terraform-eksblueprints-sysdig-addon) | Sysdig CNAPP helps you stop cloud and container security attacks with no wasted time. |
 | [Tetrate Istio](https://github.com/tetratelabs/terraform-eksblueprints-tetrate-istio-addon) | Tetrate Istio Distro is an open source project from Tetrate that provides vetted builds of Istio tested against all major cloud platforms. |
+| [NetApp ONTAP Astra Trident](https://github.com/NetApp/terraform-aws-netapp-fsxn-eks-addon) | NetApp's Astra Trident provides dynamic storage orchestration for FSx for NetApp ONTAP using a Container Storage Interface (CSI) compliant driver. |


### PR DESCRIPTION
Add Amazon FSx for NetApp ONTAP CSI driver as a new partner add-on

### What does this PR do?
Add Amazon FSx for NetApp ONTAP CSI driver as a new partner add-on to the documentation 

### Motivation
New add-on created for Amazon FSx for NetApp ONTAP CSI driver by NetApp as was missing in the docs

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

