### PR TITLE
fix: Set either name or name_prefix for fargate_fluentbit log group, not both

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2182,7 +2182,7 @@ module "external_secrets" {
 
 locals {
   fargate_fluentbit_policy_name = try(var.fargate_fluentbit_cw_log_group.create, true) ? try(var.fargate_fluentbit.policy_name, "${var.cluster_name}-fargate-fluentbit-logs") : null
-  fargate_fluentbit_cw_log_group_name = try(var.fargate_fluentbit_cw_log_group.create, true) ? try(var.fargate_fluentbit_cw_log_group.name, "/${var.cluster_name}/fargate-fluentbit-logs") : null
+  fargate_fluentbit_cw_log_group_name = try(var.fargate_fluentbit_cw_log_group.name, "/${var.cluster_name}/fargate-fluentbit-logs")
 }
 
 resource "aws_cloudwatch_log_group" "fargate_fluentbit" {

--- a/main.tf
+++ b/main.tf
@@ -2181,7 +2181,7 @@ module "external_secrets" {
 ################################################################################
 
 locals {
-  fargate_fluentbit_policy_name = try(var.fargate_fluentbit_cw_log_group.create, true) ? try(var.fargate_fluentbit.policy_name, "${var.cluster_name}-fargate-fluentbit-logs") : null
+  fargate_fluentbit_policy_name       = try(var.fargate_fluentbit_cw_log_group.create, true) ? try(var.fargate_fluentbit.policy_name, "${var.cluster_name}-fargate-fluentbit-logs") : null
   fargate_fluentbit_cw_log_group_name = try(var.fargate_fluentbit_cw_log_group.name, "/${var.cluster_name}/fargate-fluentbit-logs")
 }
 

--- a/main.tf
+++ b/main.tf
@@ -2182,13 +2182,14 @@ module "external_secrets" {
 
 locals {
   fargate_fluentbit_policy_name = try(var.fargate_fluentbit_cw_log_group.create, true) ? try(var.fargate_fluentbit.policy_name, "${var.cluster_name}-fargate-fluentbit-logs") : null
+  fargate_fluentbit_cw_log_group_name = try(var.fargate_fluentbit_cw_log_group.create, true) ? try(var.fargate_fluentbit_cw_log_group.name, "/${var.cluster_name}/fargate-fluentbit-logs") : null
 }
 
 resource "aws_cloudwatch_log_group" "fargate_fluentbit" {
   count = try(var.fargate_fluentbit_cw_log_group.create, true) && var.enable_fargate_fluentbit ? 1 : 0
 
-  name              = try(var.fargate_fluentbit_cw_log_group.name, null)
-  name_prefix       = try(var.fargate_fluentbit_cw_log_group.name_prefix, "/${var.cluster_name}/fargate-fluentbit-logs")
+  name              = try(var.fargate_fluentbit_cw_log_group.use_name_prefix, true) ? null : local.fargate_fluentbit_cw_log_group_name
+  name_prefix       = try(var.fargate_fluentbit_cw_log_group.use_name_prefix, true) ? try(var.fargate_fluentbit_cw_log_group.name_prefix, "${local.fargate_fluentbit_cw_log_group_name}-") : null
   retention_in_days = try(var.fargate_fluentbit_cw_log_group.retention, 90)
   kms_key_id        = try(var.fargate_fluentbit_cw_log_group.kms_key_arn, null)
   skip_destroy      = try(var.fargate_fluentbit_cw_log_group.skip_destroy, false)

--- a/main.tf
+++ b/main.tf
@@ -2189,7 +2189,7 @@ resource "aws_cloudwatch_log_group" "fargate_fluentbit" {
   count = try(var.fargate_fluentbit_cw_log_group.create, true) && var.enable_fargate_fluentbit ? 1 : 0
 
   name              = try(var.fargate_fluentbit_cw_log_group.use_name_prefix, true) ? null : local.fargate_fluentbit_cw_log_group_name
-  name_prefix       = try(var.fargate_fluentbit_cw_log_group.use_name_prefix, true) ? try(var.fargate_fluentbit_cw_log_group.name_prefix, "${local.fargate_fluentbit_cw_log_group_name}-") : null
+  name_prefix       = try(var.fargate_fluentbit_cw_log_group.use_name_prefix, true) ? local.fargate_fluentbit_cw_log_group_name : null
   retention_in_days = try(var.fargate_fluentbit_cw_log_group.retention, 90)
   kms_key_id        = try(var.fargate_fluentbit_cw_log_group.kms_key_arn, null)
   skip_destroy      = try(var.fargate_fluentbit_cw_log_group.skip_destroy, false)


### PR DESCRIPTION
### What does this PR do?

Fixes conflicting configuration arguments when creating `fargate_fluentbit` Cloudwatch log group, matching behavior of AWS for Fluent-bit configuration.

### Motivation

- Resolves #218 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?