### PR TITLE
fix: FluenBit add-on CW Log group fix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -680,6 +680,14 @@ module "aws_for_fluentbit" {
       value = local.aws_for_fluentbit_cw_log_group_name
     },
     {
+      name  = "cloudWatchLogs.logGroupTemplate"
+      value = ""
+    },
+    {
+      name  = "cloudWatchLogs.autoCreateGroup"
+      value = false
+    },
+    {
       name  = "cloudWatchLogs.region"
       value = local.region
     }],

--- a/main.tf
+++ b/main.tf
@@ -591,7 +591,7 @@ data "aws_iam_policy_document" "aws_for_fluentbit" {
       sid    = "CreateCWLogs"
       effect = "Allow"
       resources = [
-        "arn:${local.partition}:logs:${local.region}:${local.account_id}:log-group:${try(var.aws_for_fluentbit_cw_log_group.name, "*")}",
+        "arn:${local.partition}:logs:${local.region}:${local.account_id}:log-group:${try(var.aws_for_fluentbit_cw_log_group.name, "*")}:*",
       ]
 
       actions = [
@@ -674,6 +674,10 @@ module "aws_for_fluentbit" {
     {
       name  = "cloudWatch.region"
       value = local.region
+    },
+    {
+      name  = "cloudWatchLogs.logGroupName"
+      value = local.aws_for_fluentbit_cw_log_group_name
     },
     {
       name  = "cloudWatchLogs.region"


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

- FluentBit Helm Chart is trying to create a new CW Log Group by default with name `/aws/eks/fluentbit-cloudwatch/logs`. We are disabling that using set values. Users can enable but its not advisable as this module not configuring the IRSA policies for this log group
- This add-on module provides a better approach for setting up a CloudWatch Log Group for FluentBit while ensuring proper IRSA policies. Users can provide their Log group name, or the module will set it as `/${var.cluster_name}/aws-fluentbit-logs` if not specified.
- Adds a fix to IAM policy to ensure log stream can be queried without any errors

<!-- What inspired you to submit this pull request? -->
- Resolves #227

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
