### PR TITLE
fix: Conditional check when spot termination is disabled when karpenter is enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2569,7 +2569,7 @@ data "aws_iam_policy_document" "karpenter" {
   }
 
   dynamic "statement" {
-    for_each = var.karpenter_enable_spot_termination ? [1] : []
+    for_each = local.karpenter_enable_spot_termination ? [1] : []
 
     content {
       actions = [
@@ -2711,7 +2711,7 @@ module "karpenter" {
   namespace        = local.karpenter_namespace
   create_namespace = try(var.karpenter.create_namespace, true)
   chart            = try(var.karpenter.chart, "karpenter")
-  chart_version    = try(var.karpenter.chart_version, "v0.29.2")
+  chart_version    = try(var.karpenter.chart_version, "v0.30.0")
   repository       = try(var.karpenter.repository, "oci://public.ecr.aws/karpenter")
   values           = try(var.karpenter.values, [])
 
@@ -2758,7 +2758,7 @@ module "karpenter" {
       },
       {
         name  = "settings.aws.interruptionQueueName"
-        value = module.karpenter_sqs.queue_name
+        value = local.karpenter_enable_spot_termination ? module.karpenter_sqs.queue_name : ""
       },
       {
         name  = "serviceAccount.name"


### PR DESCRIPTION
### What does this PR do? 

1. Adds a check when `karpenter_enable_spot_termination=false` to provide `""` for the value of `interruptionQueue`.
2. Also bumping karpenter version to `0.30.0`

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #236 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
