### PR TITLE
docs: Add a note in LBC doc to set enableServiceMutatorWebhook to false

### DIFF
--- a/docs/addons/aws-load-balancer-controller.md
+++ b/docs/addons/aws-load-balancer-controller.md
@@ -6,6 +6,9 @@
 
 In order to deploy the AWS Load Balancer Controller Addon via [EKS Blueprints Addons](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons), reference the following parameters under the `module.eks_blueprints_addons`.
 
+
+> **_NOTE_**: In versions 2.5 and newer, the AWS Load Balancer Controller becomes the default controller for Kubernetes service resources with the type: LoadBalancer and makes an AWS Network Load Balancer (NLB) for each service. It does this by making a mutating webhook for services, which sets the spec.loadBalancerClass field to service.k8s.aws/nlb for new services of type: LoadBalancer. You can turn off this feature and revert to using the legacy Cloud Provider as the default controller, by setting the helm chart value enableServiceMutatorWebhook to false. The cluster won't provision new Classic Load Balancers for your services unless you turn off this feature. Existing Classic Load Balancers will continue to work.
+
 ```hcl
 module "eks_blueprints_addons" {
 

--- a/docs/addons/aws-load-balancer-controller.md
+++ b/docs/addons/aws-load-balancer-controller.md
@@ -20,6 +20,10 @@ module "eks_blueprints_addons" {
         name  = "podDisruptionBudget.maxUnavailable"
         value = 1
       },
+      {
+        name  = "enableServiceMutatorWebhook"
+        value = "false"
+      }
     ]
   }
 ```

--- a/main.tf
+++ b/main.tf
@@ -3317,7 +3317,7 @@ module "aws_gateway_api_controller" {
   namespace        = local.aws_gateway_api_controller_namespace
   create_namespace = try(var.aws_gateway_api_controller.create_namespace, true)
   chart            = try(var.aws_gateway_api_controller.chart, "aws-gateway-controller-chart")
-  chart_version    = try(var.aws_gateway_api_controller.chart_version, "v0.0.15")
+  chart_version    = try(var.aws_gateway_api_controller.chart_version, "v0.0.16")
   repository       = try(var.aws_gateway_api_controller.repository, "oci://public.ecr.aws/aws-application-networking-k8s")
   values           = try(var.aws_gateway_api_controller.values, [])
 

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -145,12 +145,21 @@ module "eks_blueprints_addons" {
   enable_external_dns                          = true
   enable_external_secrets                      = true
   # enable_gatekeeper                            = true
-  enable_ingress_nginx                = true
+  enable_ingress_nginx = true
+
+  # Turn off mutation webhook for services to avoid ordering issue
   enable_aws_load_balancer_controller = true
-  enable_metrics_server               = true
-  enable_vpa                          = true
-  enable_fargate_fluentbit            = true
-  enable_aws_for_fluentbit            = true
+  aws_load_balancer_controller = {
+    set = [{
+      name  = "enableServiceMutatorWebhook"
+      value = "false"
+    }]
+  }
+
+  enable_metrics_server    = true
+  enable_vpa               = true
+  enable_fargate_fluentbit = true
+  enable_aws_for_fluentbit = true
   aws_for_fluentbit = {
     s3_bucket_arns = [
       module.velero_backup_s3_bucket.s3_bucket_arn,


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

We do not really have a way to establish an install order of addons. This PR is used to document the issue customers could face when using LBC as it now inserts a mutation webhook for services. As a result addons that have services may timeout waiting for the webhook to be available. Users can safely turn off the webhook if they are not using the `serviceType: LoadBalancer` in any of their software. If they are using it then they should deploy the LBC add-on first.

1. Adds a documentation note to set `enableServiceMutatorWebhook` to `false`.
2. Bumps API gateway controller to 0.0.16 due to an issue noticed during testing.

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #233 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
