### PR TITLE
feat: Adding support for Container Insights on AWS for Fluent Bit module

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ module "eks_blueprints_addons" {
 | [aws_iam_role_policy_attachment.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_config_map_v1.aws_logging](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1) | resource |
+| [kubernetes_config_map_v1_data.aws_for_fluentbit_containerinsights](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1_data) | resource |
 | [kubernetes_namespace_v1.aws_observability](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 | [time_sleep.this](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |

--- a/docs/addons/aws-for-fluentbit.md
+++ b/docs/addons/aws-for-fluentbit.md
@@ -43,7 +43,7 @@ If you want to enable [Container Insights on Amazon EKS](https://docs.aws.amazon
 Verify aws-for-fluentbit pods are running.
 
 ```sh
-$ kubectl -n kube-system get pods -l app.kubernetes.io/name=aws-for-fluent-bit 
+$ kubectl -n kube-system get pods -l app.kubernetes.io/name=aws-for-fluent-bit
 NAME                       READY   STATUS    RESTARTS   AGE
 aws-for-fluent-bit-6lhkj   1/1     Running   0          15m
 aws-for-fluent-bit-sbn9b   1/1     Running   0          15m

--- a/docs/addons/aws-for-fluentbit.md
+++ b/docs/addons/aws-for-fluentbit.md
@@ -22,10 +22,19 @@ You can optionally customize the Helm chart that deploys AWS for Fluent Bit via 
   }
   aws_for_fluentbit = {
     name          = "aws-for-fluent-bit"
-    chart_version = "0.1.24"
+    chart_version = "0.1.28"
     repository    = "https://aws.github.io/eks-charts"
     namespace     = "kube-system"
     values        = [templatefile("${path.module}/values.yaml", {})]
+  }
+```
+
+If you want to enable [Container Insights on Amazon EKS](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-EKS-quickstart.html) through Fluent Bit, you need to add the following parameter in your configuration
+
+```hcl
+  enable_aws_for_fluentbit = true
+  aws_for_fluentbit = {
+    enable_containerinsights = true
   }
 ```
 
@@ -34,9 +43,11 @@ You can optionally customize the Helm chart that deploys AWS for Fluent Bit via 
 Verify aws-for-fluentbit pods are running.
 
 ```sh
-$ kuebctl get pods -n kube-system
-NAME                                                         READY   STATUS    RESTARTS       AGE
-aws-for-fluent-bit-6kp66                                     1/1     Running   0              172m
+$ kubectl -n kube-system get pods -l app.kubernetes.io/name=aws-for-fluent-bit 
+NAME                       READY   STATUS    RESTARTS   AGE
+aws-for-fluent-bit-6lhkj   1/1     Running   0          15m
+aws-for-fluent-bit-sbn9b   1/1     Running   0          15m
+aws-for-fluent-bit-svhwq   1/1     Running   0          15m
 ```
 
 Open the CloudWatch console at https://console.aws.amazon.com/cloudwatch/
@@ -47,6 +58,12 @@ In the navigation pane, choose Log groups.
 Make sure that you're in the Region where you deployed Fluent Bit.
 
 Check the list of log groups in the Region. You should see the following:
+
+```
+/aws/eks/complete/aws-fluentbit-logs
+```
+
+If you enabled Container Insights, you should also see the following Log Groups in your CloudWatch Console.
 
 ```
 /aws/containerinsights/Cluster_Name/application

--- a/docs/addons/aws-for-fluentbit.md
+++ b/docs/addons/aws-for-fluentbit.md
@@ -29,7 +29,7 @@ You can optionally customize the Helm chart that deploys AWS for Fluent Bit via 
   }
 ```
 
-If you want to enable [Container Insights on Amazon EKS](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-EKS-quickstart.html) through Fluent Bit, you need to add the following parameter in your configuration
+If you want to enable [Container Insights on Amazon EKS](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-EKS-quickstart.html) through Fluent Bit, you need to add the following parameter in your configuration:
 
 ```hcl
   enable_aws_for_fluentbit = true

--- a/main.tf
+++ b/main.tf
@@ -656,7 +656,7 @@ module "aws_for_fluentbit" {
   namespace        = local.aws_for_fluentbit_namespace
   create_namespace = try(var.aws_for_fluentbit.create_namespace, false)
   chart            = try(var.aws_for_fluentbit.chart, "aws-for-fluent-bit")
-  chart_version    = try(var.aws_for_fluentbit.chart_version, "0.1.28")
+  chart_version    = try(var.aws_for_fluentbit.chart_version, "0.1.30")
   repository       = try(var.aws_for_fluentbit.repository, "https://aws.github.io/eks-charts")
   values           = try(var.aws_for_fluentbit.values, [])
 
@@ -748,6 +748,232 @@ module "aws_for_fluentbit" {
   }
 
   tags = var.tags
+}
+
+resource "kubernetes_config_map_v1_data" "aws_for_fluentbit_containerinsights" {
+  count      = var.enable_aws_for_fluentbit && try(var.aws_for_fluentbit.enable_containerinsights, false) ? 1 : 0
+  depends_on = [module.aws_for_fluentbit]
+  force      = true
+
+  metadata {
+    name      = "aws-for-fluent-bit"
+    namespace = local.aws_for_fluentbit_namespace
+  }
+
+  data = {
+    "fluent-bit.conf" = try(
+      var.aws_for_fluentbit.fluentbit_conf,
+      <<-EOT
+        [SERVICE]
+          Flush 5
+          Grace 30
+          Log_Level info
+          Daemon off
+          Parsers_File parsers.conf
+          HTTP_Server On
+          HTTP_Listen 0.0.0.0
+          HTTP_Port 2020
+          storage.path /var/fluent-bit/state/flb-storage/
+          storage.sync normal
+          storage.checksum off
+          storage.backlog.mem_limit 5M
+
+        @INCLUDE application-log.conf
+        @INCLUDE dataplane-log.conf
+        @INCLUDE host-log.conf
+      EOT
+    )
+    "application-log.conf" = try(
+      var.aws_for_fluentbit.application_log_conf,
+      <<-EOT
+        [INPUT]
+            Name tail
+            Tag application.*
+            Exclude_Path /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+            Path /var/log/containers/*.log
+            multiline.parser docker, cri
+            DB /var/fluent-bit/state/flb_container.db
+            Mem_Buf_Limit 50MB
+            Skip_Long_Lines On
+            Refresh_Interval 10
+            Rotate_Wait 30
+            storage.type filesystem
+            Read_from_Head Off
+
+        [INPUT]
+            Name tail
+            Tag application.*
+            Path /var/log/containers/fluent-bit*
+            multiline.parser docker, cri
+            DB /var/fluent-bit/state/flb_log.db
+            Mem_Buf_Limit 5MB
+            Skip_Long_Lines On
+            Refresh_Interval 10
+            Read_from_Head Off
+
+        [INPUT]
+            Name tail
+            Tag application.*
+            Path /var/log/containers/cloudwatch-agent*
+            multiline.parser docker, cri
+            DB /var/fluent-bit/state/flb_cwagent.db
+            Mem_Buf_Limit 5MB
+            Skip_Long_Lines On
+            Refresh_Interval 10
+            Read_from_Head Off
+
+        [FILTER]
+            Name kubernetes
+            Match application.*
+            Kube_URL https://kubernetes.default.svc:443
+            Kube_Tag_Prefix application.var.log.containers.
+            Merge_Log On
+            Merge_Log_Key log_processed
+            K8S-Logging.Parser On
+            K8S-Logging.Exclude Off
+            Labels Off
+            Annotations Off
+            Use_Kubelet On
+            Kubelet_Port 10250
+            Buffer_Size 0
+
+        [OUTPUT]
+            Name cloudwatch_logs
+            Match application.*
+            region ${local.region}
+            log_group_name /aws/containerinsights/${local.cluster_name}/application
+            log_stream_prefix $${HOSTNAME}-
+            auto_create_group true
+            extra_user_agent container-insights
+            workers 1
+      EOT
+    )
+    "dataplane-log.conf" = try(
+      var.aws_for_fluentbit.dataplane_log_conf,
+      <<-EOT
+        [INPUT]
+            Name systemd
+            Tag dataplane.systemd.*
+            Systemd_Filter _SYSTEMD_UNIT=docker.service
+            Systemd_Filter _SYSTEMD_UNIT=containerd.service
+            Systemd_Filter _SYSTEMD_UNIT=kubelet.service
+            DB /var/fluent-bit/state/systemd.db
+            Path /var/log/journal
+            Read_From_Tail On
+
+        [INPUT]
+            Name tail
+            Tag dataplane.tail.*
+            Path /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+            multiline.parser docker, cri
+            DB /var/fluent-bit/state/flb_dataplane_tail.db
+            Mem_Buf_Limit 50MB
+            Skip_Long_Lines On
+            Refresh_Interval 10
+            Rotate_Wait 30
+            storage.type filesystem
+            Read_from_Head Off
+
+        [FILTER]
+            Name modify
+            Match dataplane.systemd.*
+            Rename _HOSTNAME hostname
+            Rename _SYSTEMD_UNIT systemd_unit
+            Rename MESSAGE message
+            Remove_regex ^((?!hostname|systemd_unit|message).)*$
+
+        [FILTER]
+            Name aws
+            Match dataplane.*
+            imds_version v2
+
+        [OUTPUT]
+            Name cloudwatch_logs
+            Match dataplane.*
+            region ${local.region}
+            log_group_name /aws/containerinsights/${local.cluster_name}/dataplane
+            log_stream_prefix $${HOSTNAME}-
+            auto_create_group true
+            extra_user_agent container-insights
+      EOT
+    )
+    "host-log.conf" = try(
+      var.aws_for_fluentbit.host_log_conf,
+      <<-EOT
+        [INPUT]
+            Name tail
+            Tag host.dmesg
+            Path /var/log/dmesg
+            Key message
+            DB /var/fluent-bit/state/flb_dmesg.db
+            Mem_Buf_Limit 5MB
+            Skip_Long_Lines On
+            Refresh_Interval 10
+            Read_from_Head Off
+
+        [INPUT]
+            Name tail
+            Tag host.messages
+            Path /var/log/messages
+            Parser syslog
+            DB /var/fluent-bit/state/flb_messages.db
+            Mem_Buf_Limit 5MB
+            Skip_Long_Lines On
+            Refresh_Interval 10
+            Read_from_Head Off
+
+        [INPUT]
+            Name tail
+            Tag host.secure
+            Path /var/log/secure
+            Parser syslog
+            DB /var/fluent-bit/state/flb_secure.db
+            Mem_Buf_Limit 5MB
+            Skip_Long_Lines On
+            Refresh_Interval 10
+            Read_from_Head Off
+
+        [FILTER]
+            Name aws
+            Match host.*
+            imds_version v2
+
+        [OUTPUT]
+            Name cloudwatch_logs
+            Match host.*
+            region ${local.region}
+            log_group_name /aws/containerinsights/${local.cluster_name}/host
+            log_stream_prefix $${HOSTNAME}.
+            auto_create_group true
+            extra_user_agent container-insights
+      EOT
+    )
+    "parsers.conf" = try(
+      var.aws_for_fluentbit.parsers_conf,
+      <<-EOT
+        [PARSER]
+            Name syslog
+            Format regex
+            Regex ^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+            Time_Key time
+            Time_Format %b %d %H:%M:%S
+
+        [PARSER]
+            Name container_firstline
+            Format regex
+            Regex (?<log>(?<="log":")\S(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
+            Time_Key time
+            Time_Format %Y-%m-%dT%H:%M:%S.%LZ
+
+        [PARSER]
+            Name cwagent_firstline
+            Format regex
+            Regex (?<log>(?<="log":")\d{4}[\/-]\d{1,2}[\/-]\d{1,2}[ T]\d{2}:\d{2}:\d{2}(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
+            Time_Key time
+            Time_Format %Y-%m-%dT%H:%M:%S.%LZ
+      EOT
+    )
+  }
 }
 
 ################################################################################

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -144,8 +144,8 @@ module "eks_blueprints_addons" {
   enable_kube_prometheus_stack                 = true
   enable_external_dns                          = true
   enable_external_secrets                      = true
-  # enable_gatekeeper                            = true
-  enable_ingress_nginx = true
+  enable_gatekeeper                            = true
+  # enable_ingress_nginx                         = true
 
   # Turn off mutation webhook for services to avoid ordering issue
   enable_aws_load_balancer_controller = true
@@ -160,7 +160,19 @@ module "eks_blueprints_addons" {
   enable_vpa               = true
   enable_fargate_fluentbit = true
   enable_aws_for_fluentbit = true
+  aws_for_fluentbit_cw_log_group = {
+    create          = true
+    use_name_prefix = true # Set this to true to enable name prefix
+    name_prefix     = "eks-cluster-logs-"
+    retention       = 7
+  }
   aws_for_fluentbit = {
+    enable_containerinsights = true
+    chart_version            = "0.1.28"
+    set = [{
+      name  = "cloudWatchLogs.autoCreateGroup"
+      value = true
+    }]
     s3_bucket_arns = [
       module.velero_backup_s3_bucket.s3_bucket_arn,
       "${module.velero_backup_s3_bucket.s3_bucket_arn}/logs/*"


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

* Add support for enabling [Container Insights on Amazon EKS](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-EKS-quickstart.html) through AWS for Fluent Bit module, by replacing the `aws-for-fluent-bit` ConfigMap, based on the template available [here](https://github.com/aws-samples/amazon-cloudwatch-container-insights/blob/main/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml#L38-L240).

```hcl
aws_for_fluentbit = {
    enable_containerinsights = true
}
```
* Fix `docs/addons/aws-for-fluentbit`
* Bump AWS for Fluent Bit Chart version to `0.1.30`

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #231 

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
