### PR TITLE
fixes #247 (allow hashicorp/aws 4.x)

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 4.47"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
### What does this PR do?
Restore support for hashicorp/aws provider v4.x

### Motivation
While migrating to v5 of aws-eks-blueprints-addons, I encountered a new requirement for a new major version of the hashicorp/aws.
I was unable to find documentation for why the provider was bumped (except, maybe, to keep versions aligned). There are other cases of aws related terraform modules moving to their v5 but still supporting provider v4.

I this PR, I kept the previous requirement (">= 4.47") but, it may also work with ">= 4.67.0" for the latest of v4.
