### PR TITLE
feat: Add `route53:listtagsforresource` to `external-dns`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2221,6 +2221,11 @@ data "aws_iam_policy_document" "external_dns" {
   }
 
   statement {
+    actions   = ["route53:ListTagsForResource"]
+    resources = var.external_dns_route53_zone_arns
+  }
+
+  statement {
     actions = [
       "route53:ListHostedZones",
       "route53:ListResourceRecordSets",


### PR DESCRIPTION
We need to have access to the tags on the Route 53 zone.

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

The addition of `route53:ListTagsForResource` to the external-dns IAM policy.

### Motivation

After having a chat with @csantanapr who informed me of this project I decided to take this project for a spin. There are a few things missing from this project preventing us from using this, this issue being one of them. 

<!-- What inspired you to submit this pull request? -->

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
