### PR TITLE
fixes #261 - aws_caller_identity and aws_partition called for all modules, even if disabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,7 @@ module "argo_rollouts" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_argo_rollouts ? 1 : 0)
   create = var.enable_argo_rollouts
 
   # Disable helm release
@@ -129,6 +130,7 @@ module "argo_workflows" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_argo_workflows ? 1 : 0)
   create = var.enable_argo_workflows
 
   # Disable helm release
@@ -185,6 +187,7 @@ module "argocd" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_argocd ? 1 : 0)
   create = var.enable_argocd
 
   # Disable helm release
@@ -242,6 +245,7 @@ module "argo_events" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_argo_events ? 1 : 0)
   create = var.enable_argo_events
 
   # https://github.com/argoproj/argo-helm/tree/main/charts/argo-events
@@ -301,6 +305,7 @@ module "aws_cloudwatch_metrics" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_aws_cloudwatch_metrics ? 1 : 0)
   create = var.enable_aws_cloudwatch_metrics
 
   # Disable helm release
@@ -467,6 +472,7 @@ module "aws_efs_csi_driver" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_aws_efs_csi_driver ? 1 : 0)
   create = var.enable_aws_efs_csi_driver
 
   # Disable helm release
@@ -645,6 +651,7 @@ module "aws_for_fluentbit" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_aws_for_fluentbit ? 1 : 0)
   create = var.enable_aws_for_fluentbit
 
   # Disable helm release
@@ -752,7 +759,7 @@ module "aws_for_fluentbit" {
 
 resource "kubernetes_config_map_v1_data" "aws_for_fluentbit_containerinsights" {
   count      = var.enable_aws_for_fluentbit && try(var.aws_for_fluentbit.enable_containerinsights, false) ? 1 : 0
-  depends_on = [module.aws_for_fluentbit]
+  depends_on = [module.aws_for_fluentbit[0]]
   force      = true
 
   metadata {
@@ -1042,6 +1049,7 @@ module "aws_fsx_csi_driver" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_aws_fsx_csi_driver ? 1 : 0)
   create = var.enable_aws_fsx_csi_driver
 
   # Disable helm release
@@ -1405,6 +1413,7 @@ module "aws_load_balancer_controller" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_aws_load_balancer_controller ? 1 : 0)
   create = var.enable_aws_load_balancer_controller
 
   # Disable helm release
@@ -1518,6 +1527,7 @@ module "aws_node_termination_handler_sqs" {
   source  = "terraform-aws-modules/sqs/aws"
   version = "4.0.1"
 
+  count = (var.enable_aws_node_termination_handler ? 1 : 0)
   create = var.enable_aws_node_termination_handler
 
   name = try(var.aws_node_termination_handler_sqs.queue_name, "aws-nth-${var.cluster_name}")
@@ -1587,7 +1597,7 @@ resource "aws_cloudwatch_event_target" "aws_node_termination_handler" {
 
   rule      = aws_cloudwatch_event_rule.aws_node_termination_handler[each.key].name
   target_id = "AWSNodeTerminationHandlerQueueTarget"
-  arn       = module.aws_node_termination_handler_sqs.queue_arn
+  arn       = module.aws_node_termination_handler_sqs.queue_arn[0]
 }
 
 data "aws_iam_policy_document" "aws_node_termination_handler" {
@@ -1612,7 +1622,7 @@ data "aws_iam_policy_document" "aws_node_termination_handler" {
       "sqs:DeleteMessage",
       "sqs:ReceiveMessage",
     ]
-    resources = [module.aws_node_termination_handler_sqs.queue_arn]
+    resources = [module.aws_node_termination_handler_sqs.queue_arn[0]]
   }
 }
 
@@ -1620,6 +1630,7 @@ module "aws_node_termination_handler" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_aws_node_termination_handler ? 1 : 0)
   create = var.enable_aws_node_termination_handler
 
   # Disable helm release
@@ -1673,7 +1684,7 @@ module "aws_node_termination_handler" {
         value = local.region
       },
       { name  = "queueURL"
-        value = module.aws_node_termination_handler_sqs.queue_url
+        value = module.aws_node_termination_handler_sqs.queue_url[0]
       },
       {
         name  = "enableSqsTerminationDraining"
@@ -1745,6 +1756,7 @@ module "aws_privateca_issuer" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_aws_privateca_issuer ? 1 : 0)
   create = var.enable_aws_privateca_issuer
 
   # Disable helm release
@@ -1864,6 +1876,7 @@ module "cert_manager" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_cert_manager ? 1 : 0)
   create = var.enable_cert_manager
 
   # Disable helm release
@@ -2011,6 +2024,7 @@ module "cluster_autoscaler" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_cluster_autoscaler ? 1 : 0)
   create = var.enable_cluster_autoscaler
 
   # Disable helm release
@@ -2116,6 +2130,7 @@ module "cluster_proportional_autoscaler" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_cluster_proportional_autoscaler ? 1 : 0)
   create = var.enable_cluster_proportional_autoscaler
 
   # Disable helm release
@@ -2198,8 +2213,8 @@ resource "aws_eks_addon" "this" {
   tags = var.tags
 
   depends_on = [
-    module.cert_manager.name,
-    module.cert_manager.namespace,
+    module.cert_manager.name,[0]
+    module.cert_manager.namespace,[0]
   ]
 }
 
@@ -2238,6 +2253,7 @@ module "external_dns" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_external_dns ? 1 : 0)
   create = var.enable_external_dns
 
   # Disable helm release
@@ -2391,6 +2407,7 @@ module "external_secrets" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_external_secrets ? 1 : 0)
   create = var.enable_external_secrets
 
   # Disable helm release
@@ -2617,6 +2634,7 @@ module "gatekeeper" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_gatekeeper ? 1 : 0)
   create = var.enable_gatekeeper
 
   # Disable helm release
@@ -2673,6 +2691,7 @@ module "ingress_nginx" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_ingress_nginx ? 1 : 0)
   create = var.enable_ingress_nginx
 
   # Disable helm release
@@ -2809,7 +2828,7 @@ data "aws_iam_policy_document" "karpenter" {
         "sqs:GetQueueUrl",
         "sqs:ReceiveMessage",
       ]
-      resources = [module.karpenter_sqs.queue_arn]
+      resources = [module.karpenter_sqs.queue_arn[0]]
     }
   }
 }
@@ -2865,7 +2884,7 @@ resource "aws_cloudwatch_event_target" "karpenter" {
 
   rule      = aws_cloudwatch_event_rule.karpenter[each.key].name
   target_id = "KarpenterQueueTarget"
-  arn       = module.karpenter_sqs.queue_arn
+  arn       = module.karpenter_sqs.queue_arn[0]
 }
 
 data "aws_iam_policy_document" "karpenter_assume_role" {
@@ -2931,6 +2950,7 @@ module "karpenter" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_karpenter ? 1 : 0)
   create = var.enable_karpenter
 
   # Disable helm release
@@ -2989,7 +3009,7 @@ module "karpenter" {
       },
       {
         name  = "settings.aws.interruptionQueueName"
-        value = local.karpenter_enable_spot_termination ? module.karpenter_sqs.queue_name : ""
+        value = local.karpenter_enable_spot_termination ? module.karpenter_sqs.queue_name : ""[0]
       },
       {
         name  = "serviceAccount.name"
@@ -3051,6 +3071,7 @@ module "kube_prometheus_stack" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_kube_prometheus_stack ? 1 : 0)
   create = var.enable_kube_prometheus_stack
 
   # Disable helm release
@@ -3107,6 +3128,7 @@ module "metrics_server" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_metrics_server ? 1 : 0)
   create = var.enable_metrics_server
 
   # Disable helm release
@@ -3163,6 +3185,7 @@ module "secrets_store_csi_driver" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_secrets_store_csi_driver ? 1 : 0)
   create = var.enable_secrets_store_csi_driver
 
   # Disable helm release
@@ -3219,6 +3242,7 @@ module "secrets_store_csi_driver_provider_aws" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_secrets_store_csi_driver_provider_aws ? 1 : 0)
   create = var.enable_secrets_store_csi_driver_provider_aws
 
   # Disable helm release
@@ -3329,6 +3353,7 @@ module "velero" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_velero ? 1 : 0)
   create = var.enable_velero
 
   # Disable helm release
@@ -3455,6 +3480,7 @@ module "vpa" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_vpa ? 1 : 0)
   create = var.enable_vpa
 
   # Disable helm release
@@ -3538,6 +3564,7 @@ module "aws_gateway_api_controller" {
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
+  count = (var.enable_aws_gateway_api_controller ? 1 : 0)
   create = var.enable_aws_gateway_api_controller
 
   # Disable helm release

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,76 +1,76 @@
 output "argo_rollouts" {
   description = "Map of attributes of the Helm release created"
-  value       = module.argo_rollouts
+  value       = try(module.argo_rollouts[0],null)
 }
 
 output "argo_workflows" {
   description = "Map of attributes of the Helm release created"
-  value       = module.argo_workflows
+  value       = try(module.argo_workflows[0],null)
 }
 
 output "argocd" {
   description = "Map of attributes of the Helm release created"
-  value       = module.argocd
+  value       = try(module.argocd[0],null)
 }
 
 output "argo_events" {
   description = "Map of attributes of the Helm release created"
-  value       = module.argo_events
+  value       = try(module.argo_events[0],null)
 }
 
 output "aws_cloudwatch_metrics" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.aws_cloudwatch_metrics
+  value       = try(module.aws_cloudwatch_metrics[0],null)
 }
 
 output "aws_efs_csi_driver" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.aws_efs_csi_driver
+  value       = try(module.aws_efs_csi_driver[0],null)
 }
 
 output "aws_for_fluentbit" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.aws_for_fluentbit
+  value       = try(module.aws_for_fluentbit[0],null)
 }
 
 output "aws_fsx_csi_driver" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.aws_fsx_csi_driver
+  value       = try(module.aws_fsx_csi_driver[0],null)
 }
 
 output "aws_load_balancer_controller" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.aws_load_balancer_controller
+  value       = try(module.aws_load_balancer_controller[0],null)
 }
 
 output "aws_node_termination_handler" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value = merge(
+  value = try(merge(
     module.aws_node_termination_handler,
     {
       sqs = module.aws_node_termination_handler_sqs
     }
-  )
+  ),null)
 }
 
 output "aws_privateca_issuer" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.aws_privateca_issuer
+  value       = try(module.aws_privateca_issuer[0],null)
 }
 
 output "cert_manager" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.cert_manager
+  value       = try(module.cert_manager[0],null)
 }
 
 output "cluster_autoscaler" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.cluster_autoscaler
+  value       = try(module.cluster_autoscaler[0],null)
 }
 
 output "cluster_proportional_autoscaler" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.cluster_proportional_autoscaler
+  value       = try(module.cluster_proportional_autoscaler[0],null)
 }
 
 output "eks_addons" {
@@ -80,12 +80,12 @@ output "eks_addons" {
 
 output "external_dns" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.external_dns
+  value       = try(module.external_dns[0],null)
 }
 
 output "external_secrets" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.external_secrets
+  value       = try(module.external_secrets[0],null)
 }
 
 output "fargate_fluentbit" {
@@ -98,12 +98,12 @@ output "fargate_fluentbit" {
 
 output "gatekeeper" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.gatekeeper
+  value       = try(module.gatekeeper[0],null)
 }
 
 output "ingress_nginx" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.ingress_nginx
+  value       = try(module.ingress_nginx[0],null)
 }
 
 output "karpenter" {
@@ -120,37 +120,37 @@ output "karpenter" {
 
 output "kube_prometheus_stack" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.kube_prometheus_stack
+  value       = try(module.kube_prometheus_stack[0],null)
 }
 
 output "metrics_server" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.metrics_server
+  value       = try(module.metrics_server[0],null)
 }
 
 output "secrets_store_csi_driver" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.secrets_store_csi_driver
+  value       = try(module.secrets_store_csi_driver[0],null)
 }
 
 output "secrets_store_csi_driver_provider_aws" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.secrets_store_csi_driver_provider_aws
+  value       = try(module.secrets_store_csi_driver_provider_aws[0],null)
 }
 
 output "velero" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.velero
+  value       = try(module.velero[0],null)
 }
 
 output "vpa" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.vpa
+  value       = try(module.vpa[0],null)
 }
 
 output "aws_gateway_api_controller" {
   description = "Map of attributes of the Helm release and IRSA created"
-  value       = module.aws_gateway_api_controller
+  value       = try(module.aws_gateway_api_controller[0],null)
 }
 
 ################################################################################
@@ -175,91 +175,91 @@ output "gitops_metadata" {
   description = "GitOps Bridge metadata"
   value = merge(
     { for k, v in {
-      iam_role_arn    = module.cert_manager.iam_role_arn
+      iam_role_arn    = module.cert_manager[0].iam_role_arn
       namespace       = local.cert_manager_namespace
       service_account = local.cert_manager_service_account
       } : "cert_manager_${k}" => v if var.enable_cert_manager
     },
     { for k, v in {
-      iam_role_arn    = module.cluster_autoscaler.iam_role_arn
+      iam_role_arn    = module.cluster_autoscaler[0].iam_role_arn
       namespace       = local.cluster_autoscaler_namespace
       service_account = local.cluster_autoscaler_service_account
       } : "cluster_autoscaler_${k}" => v if var.enable_cluster_autoscaler
     },
     { for k, v in {
-      iam_role_arn    = module.aws_cloudwatch_metrics.iam_role_arn
+      iam_role_arn    = module.aws_cloudwatch_metrics[0].iam_role_arn
       namespace       = local.aws_cloudwatch_metrics_namespace
       service_account = local.aws_cloudwatch_metrics_service_account
       } : "aws_cloudwatch_metrics_${k}" => v if var.enable_aws_cloudwatch_metrics
     },
     { for k, v in {
-      iam_role_arn               = module.aws_efs_csi_driver.iam_role_arn
+      iam_role_arn               = module.aws_efs_csi_driver[0].iam_role_arn
       namespace                  = local.aws_efs_csi_driver_namespace
       controller_service_account = local.aws_efs_csi_driver_controller_service_account
       node_service_account       = local.aws_efs_csi_driver_node_service_account
       } : "aws_efs_csi_driver_${k}" => v if var.enable_aws_efs_csi_driver
     },
     { for k, v in {
-      iam_role_arn               = module.aws_fsx_csi_driver.iam_role_arn
+      iam_role_arn               = module.aws_fsx_csi_driver[0].iam_role_arn
       namespace                  = local.aws_fsx_csi_driver_namespace
       controller_service_account = local.aws_fsx_csi_driver_controller_service_account
       node_service_account       = local.aws_fsx_csi_driver_node_service_account
       } : "aws_fsx_csi_driver_${k}" => v if var.enable_aws_fsx_csi_driver
     },
     { for k, v in {
-      iam_role_arn    = module.aws_privateca_issuer.iam_role_arn
+      iam_role_arn    = module.aws_privateca_issuer[0].iam_role_arn
       namespace       = local.aws_privateca_issuer_namespace
       service_account = local.aws_privateca_issuer_service_account
       } : "aws_privateca_issuer_${k}" => v if var.enable_aws_privateca_issuer
     },
     { for k, v in {
-      iam_role_arn    = module.external_dns.iam_role_arn
+      iam_role_arn    = module.external_dns[0].iam_role_arn
       namespace       = local.external_dns_namespace
       service_account = local.external_dns_service_account
       } : "external_dns_${k}" => v if var.enable_external_dns
     },
     { for k, v in {
-      iam_role_arn    = module.external_secrets.iam_role_arn
+      iam_role_arn    = module.external_secrets[0].iam_role_arn
       namespace       = local.external_secrets_namespace
       service_account = local.external_secrets_service_account
       } : "external_secrets_${k}" => v if var.enable_external_secrets
     },
     { for k, v in {
-      iam_role_arn    = module.aws_load_balancer_controller.iam_role_arn
+      iam_role_arn    = module.aws_load_balancer_controller[0].iam_role_arn
       namespace       = local.aws_load_balancer_controller_namespace
       service_account = local.aws_load_balancer_controller_service_account
       } : "aws_load_balancer_controller_${k}" => v if var.enable_aws_load_balancer_controller
     },
     { for k, v in {
-      iam_role_arn    = module.aws_for_fluentbit.iam_role_arn
+      iam_role_arn    = module.aws_for_fluentbit[0].iam_role_arn
       namespace       = local.aws_for_fluentbit_namespace
       service_account = local.aws_for_fluentbit_service_account
       log_group_name  = try(aws_cloudwatch_log_group.aws_for_fluentbit[0].name, null)
       } : "aws_for_fluentbit_${k}" => v if var.enable_aws_for_fluentbit && v != null
     },
     { for k, v in {
-      iam_role_arn    = module.aws_node_termination_handler.iam_role_arn
+      iam_role_arn    = module.aws_node_termination_handler[0].iam_role_arn
       namespace       = local.aws_node_termination_handler_namespace
       service_account = local.aws_node_termination_handler_service_account
       sqs_queue_url   = module.aws_node_termination_handler_sqs.queue_url
       } : "aws_node_termination_handler_${k}" => v if var.enable_aws_node_termination_handler
     },
     { for k, v in {
-      iam_role_arn               = module.karpenter.iam_role_arn
+      iam_role_arn               = module.karpenter[0].iam_role_arn
       namespace                  = local.karpenter_namespace
       service_account            = local.karpenter_service_account_name
-      sqs_queue_name             = module.karpenter_sqs.queue_name
+      sqs_queue_name             = module.karpenter_sqs[0].queue_name
       node_instance_profile_name = local.karpenter_node_instance_profile_name
       } : "karpenter_${k}" => v if var.enable_karpenter
     },
     { for k, v in {
-      iam_role_arn    = module.velero.iam_role_arn
+      iam_role_arn    = module.velero[0].iam_role_arn
       namespace       = local.velero_namespace
       service_account = local.velero_service_account
       } : "velero_${k}" => v if var.enable_velero
     },
     { for k, v in {
-      iam_role_arn    = module.aws_gateway_api_controller.iam_role_arn
+      iam_role_arn    = module.aws_gateway_api_controller[0].iam_role_arn
       namespace       = local.aws_gateway_api_controller_namespace
       service_account = local.aws_gateway_api_controller_service_account
       } : "aws_gateway_api_controller_${k}" => v if var.enable_aws_gateway_api_controller


### PR DESCRIPTION
### What does this PR do?
limits instantiation of modules that are not used

### Motivation
Current approach of a single-monolith file combined with the use of the "create" pattern cause "aws_caller_identity" and "aws_partition" to be called/instantiated for each and every module included in the file, even if they are not used.

This creates many unnecessary resources in terraform state (and confuses plans) when the module is used multiple times (say for multiple ingresses in same cluster, or multiple external-dns for multiple providers).

These are called once per included module as "aws-ia/terraform-aws-eks-blueprints-addon" includes them, and is instantiated with create=false.
To prevent unnecessary calls/instantiation, unused modules should also be guarded with the "count = (enable_m ? 1 : 0)" pattern.

- Resolves #261

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

* this is WIP, and needs testing... However, by proposing this as draft, I would hope to get some feedback

