### PR TITLE
docs: Correct Helm chart repository and version of "kube-prometheus-stack" example reference

### DIFF
--- a/docs/addons/kube-prometheus-stack.md
+++ b/docs/addons/kube-prometheus-stack.md
@@ -17,8 +17,8 @@ You can optionally customize the Helm chart that deploys Kube Prometheus Stack v
 
   kube_prometheus_stack = {
     name          = "kube-prometheus-stack"
-    chart_version = "45.10.1"
-    repository    = "https://charts.external-secrets.io"
+    chart_version = "51.2.0"
+    repository    = "https://prometheus-community.github.io/helm-charts"
     namespace     = "kube-prometheus-stack"
     values        = [templatefile("${path.module}/values.yaml", {})]
   }


### PR DESCRIPTION
- Change the repository helm chart from "https://charts.external-secrets.io" to "https://prometheus-community.github.io/helm-charts".
- Change the chart version to the current latest version.

### Motivation

<!-- What inspired you to submit this pull request? -->
- People interested in trying this add-on will be confused as to why it doesn't work. Since I have noticed it and had that problem, why not help the community with such a simple fix?
