### PR TITLE
fix: Allow `cert-manager` IAM role to assume itself

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1923,6 +1923,9 @@ module "cert_manager" {
   role_description              = try(var.cert_manager.role_description, "IRSA for cert-manger project")
   role_policies                 = lookup(var.cert_manager, "role_policies", {})
 
+  # it seems that with 1.12.3+ and 1.13.0, this is be required for IRSA to work
+  allow_self_assume_role        = local.create_cert_manager_irsa && try(var.cert_manager.create_role, true)
+
   source_policy_documents = data.aws_iam_policy_document.cert_manager[*].json
   policy_statements       = lookup(var.cert_manager, "policy_statements", [])
   policy_name             = try(var.cert_manager.policy_name, null)

--- a/main.tf
+++ b/main.tf
@@ -1927,9 +1927,7 @@ module "cert_manager" {
   role_description              = try(var.cert_manager.role_description, "IRSA for cert-manger project")
   role_policies                 = lookup(var.cert_manager, "role_policies", {})
 
-  # it seems that with 1.12.3+ and 1.13.0, this is be required for IRSA to work
-  allow_self_assume_role        = local.create_cert_manager_irsa && try(var.cert_manager.create_role, true)
-
+  allow_self_assume_role  = try(var.cert_manager.allow_self_assume_role, true)
   source_policy_documents = data.aws_iam_policy_document.cert_manager[*].json
   policy_statements       = lookup(var.cert_manager, "policy_statements", [])
   policy_name             = try(var.cert_manager.policy_name, null)


### PR DESCRIPTION
### What does this PR do?
Fixes same symptoms from https://github.com/cert-manager/cert-manager/issues/5557
Basically it seems that cert-manager DNS01 for Route53, when configured via Cluster Issuer, is not able to use the SA part of IRSA, but instead needs to assume the role.

### Motivation

- Same symptoms as https://github.com/cert-manager/cert-manager/issues/5557 but not issue in this project yet

### More

- [ X ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
