### PR TITLE
fix: Allow `aws_for_fluentbit_cw_log_group.create = false` without error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -567,7 +567,7 @@ module "aws_efs_csi_driver" {
 
 locals {
   aws_for_fluentbit_service_account   = try(var.aws_for_fluentbit.service_account_name, "aws-for-fluent-bit-sa")
-  aws_for_fluentbit_cw_log_group_name = try(var.aws_for_fluentbit_cw_log_group.create, true) ? try(var.aws_for_fluentbit_cw_log_group.name, "/aws/eks/${var.cluster_name}/aws-fluentbit-logs") : null
+  aws_for_fluentbit_cw_log_group_name = try(var.aws_for_fluentbit_cw_log_group.create, true) ? try(var.aws_for_fluentbit_cw_log_group.name, "/aws/eks/${var.cluster_name}/aws-fluentbit-logs") : ""
   aws_for_fluentbit_namespace         = try(var.aws_for_fluentbit.namespace, "kube-system")
 }
 

--- a/main.tf
+++ b/main.tf
@@ -700,7 +700,7 @@ module "aws_for_fluentbit" {
     },
     {
       name  = "cloudWatchLogs.logGroupName"
-      value = local.aws_for_fluentbit_cw_log_group_name != null ? local.aws_for_fluentbit_cw_log_group_name : ""
+      value = local.aws_for_fluentbit_cw_log_group_name
     },
     {
       name  = "cloudWatchLogs.logGroupTemplate"

--- a/main.tf
+++ b/main.tf
@@ -700,7 +700,7 @@ module "aws_for_fluentbit" {
     },
     {
       name  = "cloudWatchLogs.logGroupName"
-      value = local.aws_for_fluentbit_cw_log_group_name
+      value = local.aws_for_fluentbit_cw_log_group_name != null ? local.aws_for_fluentbit_cw_log_group_name : ""
     },
     {
       name  = "cloudWatchLogs.logGroupTemplate"


### PR DESCRIPTION
### What does this PR do?

Fix `terraform apply` to finish successfully even if `aws_for_fluentbit_cw_log_group.create = false` is set.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #270 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Change `source` and check that `terraform apply` is successful.

<details><summary>main.tf</summary><div>

```terraform
terraform {
  required_version = ">= 1.5"

  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = ">= 5.0"
    }
    kubernetes = {
      source  = "hashicorp/kubernetes"
      version = ">= 2.20"
    }
    helm = {
      source  = "hashicorp/helm"
      version = ">= 2.9"
    }
    time = {
      source  = "hashicorp/time"
      version = ">=0.9"
    }
    kubectl = {
      source  = "gavinbunney/kubectl"
      version = ">= 1.14"
    }
  }
}

locals {
  region = "us-east-2"
}

provider "aws" {
  region = local.region
}

data "aws_availability_zones" "available" {}

provider "kubernetes" {
  host                   = module.eks.cluster_endpoint
  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)

  exec {
    api_version = "client.authentication.k8s.io/v1beta1"
    command     = "aws"
    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
  }
}

provider "helm" {
  kubernetes {
    host                   = module.eks.cluster_endpoint
    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)

    exec {
      api_version = "client.authentication.k8s.io/v1beta1"
      command     = "aws"
      args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
    }
  }
}

provider "kubectl" {
  apply_retry_count      = 10
  host                   = module.eks.cluster_endpoint
  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
  load_config_file       = false

  exec {
    api_version = "client.authentication.k8s.io/v1beta1"
    command     = "aws"
    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
  }
}

data "aws_eks_cluster_auth" "this" {
  name = module.eks.cluster_name
}

locals {
  name           = "test"
  vpc_cidr       = "10.16.0.0/22"
  num_of_subnets = min(length(data.aws_availability_zones.available.names), 3)
  azs            = slice(data.aws_availability_zones.available.names, 0, local.num_of_subnets)
}

module "vpc" {
  source  = "terraform-aws-modules/vpc/aws"
  version = "5.1.1"

  name = local.name
  cidr = local.vpc_cidr
  azs  = local.azs

  public_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 2, k)]
  private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k + local.num_of_subnets * pow(2, 2))]

  enable_nat_gateway      = true
  create_igw              = true
  enable_dns_hostnames    = true
  map_public_ip_on_launch = true

  manage_default_network_acl    = true
  default_network_acl_tags      = { Name = "${local.name}-default" }
  manage_default_route_table    = true
  default_route_table_tags      = { Name = "${local.name}-default" }
  manage_default_security_group = true
  default_security_group_tags   = { Name = "${local.name}-default" }

  public_subnet_tags = {
    "kubernetes.io/role/elb" = "1"
  }
}

module "eks" {
  source  = "terraform-aws-modules/eks/aws"
  version = "19.16.0"

  cluster_name                   = local.name
  cluster_version                = "1.27"
  cluster_endpoint_public_access = true

  vpc_id     = module.vpc.vpc_id
  subnet_ids = module.vpc.public_subnets


  eks_managed_node_groups = {
    initial = {
      instance_types = ["t3.medium"]
      min_size       = 1
      desired_size   = 3

      subnet_ids = module.vpc.public_subnets
    }
  }
}


module "eks_blueprints_addons" {
  source = "git::https://github.com/fuji8/terraform-aws-eks-blueprints-addons.git?ref=a48f4ef1422e7370a5ed3ea8031ac60aa4108b2e"

  cluster_name      = module.eks.cluster_name
  cluster_endpoint  = module.eks.cluster_endpoint
  cluster_version   = module.eks.cluster_version
  oidc_provider_arn = module.eks.oidc_provider_arn

  enable_aws_for_fluentbit = true
  aws_for_fluentbit_cw_log_group = {
    create = false
  }
  aws_for_fluentbit = {
    enable_containerinsights = false
    set = [
      {
        name  = "cloudWatchLogs.enabled"
        value = false
      },
      {
        name  = "firehose.enabled"
        value = "true"
      },
      {
        name  = "firehose.deliveryStream"
        value = "hoge"
      },
      {
        name  = "cloudWatchLogs.logGroupName"
        value = ""
      }
    ]
  }
}

```

</div></details>

