### PR TITLE
fix: Karpenter permissions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2793,8 +2793,8 @@ data "aws_iam_policy_document" "karpenter" {
 
     condition {
       test     = "StringLike"
-      variable = "ec2:ResourceTag/Name"
-      values   = ["*karpenter*"]
+      variable = "ec2:ResourceTag/karpenter.sh/provisioner-name"
+      values   = ["*"]
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

Karpenter is not able to terminate instances due to misconfigured permissions
Issue: https://github.com/aws/karpenter/issues/3712
<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves https://github.com/aws/karpenter/issues/3712

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
