### PR TITLE
chore: Update CI versions to latest to fix doc publish workflow

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -7,15 +7,12 @@ on:
       - edited
       - synchronize
 
-# permissions:
-#   pull-requests: read
-
 jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.2.0
+      - uses: amannn/action-semantic-pull-request@v5.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -29,7 +29,7 @@ jobs:
       directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get root directories
         id: dirs
@@ -47,7 +47,7 @@ jobs:
         run: rm -rf $(which terraform)
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v2
         id: changes
@@ -72,7 +72,7 @@ jobs:
           restore-keys: ${{ runner.os }}-terraform-
 
       - name: Terraform min/max versions
-        uses: clowdhaus/terraform-min-max@v1.2.4
+        uses: clowdhaus/terraform-min-max@v.1.2.7
         if: steps.changes.outputs.src== 'true'
         id: minMax
         with:
@@ -103,7 +103,7 @@ jobs:
         run: rm -rf $(which terraform)
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v2
         id: changes
@@ -124,13 +124,9 @@ jobs:
           key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
           restore-keys: ${{ runner.os }}-terraform-
 
-      - name: Install tfsec
-        if: steps.changes.outputs.src== 'true'
-        run: curl -sSLo ./tfsec https://github.com/aquasecurity/tfsec/releases/download/${{ env.TFSEC_VERSION }}/tfsec-$(uname)-amd64 && chmod +x tfsec && sudo mv tfsec /usr/bin/
-
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.2.4
+        uses: clowdhaus/terraform-min-max@v.1.2.7
         if: steps.changes.outputs.src== 'true'
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -72,7 +72,7 @@ jobs:
           restore-keys: ${{ runner.os }}-terraform-
 
       - name: Terraform min/max versions
-        uses: clowdhaus/terraform-min-max@v.1.2.7
+        uses: clowdhaus/terraform-min-max@v1.2.7
         if: steps.changes.outputs.src== 'true'
         id: minMax
         with:
@@ -126,7 +126,7 @@ jobs:
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v.1.2.7
+        uses: clowdhaus/terraform-min-max@v1.2.7
         if: steps.changes.outputs.src== 'true'
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  PYTHON_VERSION: 3.x
+  PYTHON_VERSION: 3.11
 
 jobs:
   build:
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -35,9 +35,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install mike==1.1.2 \
-            mkdocs-material==9.1.4 \
-            mkdocs-include-markdown-plugin==4.0.4 \
-            mkdocs-awesome-pages-plugin==2.9.1
+            mkdocs-material==9.4.7 \
+            mkdocs-include-markdown-plugin==6.0.3 \
+            mkdocs-awesome-pages-plugin==2.9.2
 
       - name: git config
         run: |

--- a/.github/workflows/stale-issue-pr.yaml
+++ b/.github/workflows/stale-issue-pr.yaml
@@ -14,7 +14,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v6
+      - uses: actions/stale@v8
         id: stale
         with:
           ascending: true


### PR DESCRIPTION
### What does this PR do?

- Update GitHub action workflow versions to latest
- Pin python version for doc publish workflow to 3.11 (3.12 might be a bit too new for the libraries used)

### Motivation

- https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/actions/runs/6722082456/job/18269235482

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
