### PR TITLE
feat: Adding `cloudwatch_log_group` resource output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -93,6 +93,7 @@ output "fargate_fluentbit" {
   value = {
     configmap  = kubernetes_config_map_v1.aws_logging
     iam_policy = aws_iam_policy.fargate_fluentbit
+    cloudwatch_log_group = aws_cloudwatch_log_group.fargate_fluentbit
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -91,8 +91,8 @@ output "external_secrets" {
 output "fargate_fluentbit" {
   description = "Map of attributes of the configmap and IAM policy created"
   value = {
-    configmap  = kubernetes_config_map_v1.aws_logging
-    iam_policy = aws_iam_policy.fargate_fluentbit
+    configmap            = kubernetes_config_map_v1.aws_logging
+    iam_policy           = aws_iam_policy.fargate_fluentbit
     cloudwatch_log_group = aws_cloudwatch_log_group.fargate_fluentbit
   }
 }


### PR DESCRIPTION
### What does this PR do?

Add a Terraform output for `fargate_fluentbit` addon, so it can be consumed by other modules.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #293 

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->

```
# cat outputs.tf
output "fargate_fluentbit" {
 value = module.eks_blueprints_addons.fargate_fluentbit
}
```
```
# terrraform apply -auto-approve

...truncated output

Apply complete! Resources: 58 added, 0 changed, 0 destroyed.

Outputs:

configure_kubectl = "aws eks --region us-west-2 update-kubeconfig --name fargate-fluentbit"
fargate_fluentbit = {
  "cloudwatch_log_group" = [
    {
      "arn" = "arn:aws:logs:us-west-2:xxxxxxxxxxxxx:log-group:/fargate/fargate-fluentbit-logs20231101194544512300000008"
      "id" = "/fargate/fargate-fluentbit-logs20231101194544512300000008"
      "kms_key_id" = ""
      "name" = "/fargate/fargate-fluentbit-logs20231101194544512300000008"
      "name_prefix" = "/fargate/fargate-fluentbit-logs"
      "retention_in_days" = 90
      "skip_destroy" = false
      "tags" = tomap({
        "Blueprint" = "fargate"
        "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints-addons"
      })
      "tags_all" = tomap({
        "Blueprint" = "fargate"
        "GithubRepo" = "github.com/aws-ia/terraform-aws-eks-blueprints-addons"
      })
    },
  ]
  "configmap" = [
    {
      "binary_data" = tomap({})
      "data" = tomap({
        "filters.conf" = <<-EOT
        [FILTER]
          Name parser
          Match *
          Key_Name log
          Parser regex
          Preserve_Key True
          Reserve_Data True
        
        EOT
        "flb_log_cw" = "true"
        "output.conf" = <<-EOT
        [OUTPUT]
          Name cloudwatch_logs
          Match *
          region us-west-2
          log_group_name /fargate/fargate-fluentbit-logs20231101194544512300000008
          log_stream_prefix fargate-logs-
          auto_create_group true
        
        EOT
        "parsers.conf" = <<-EOT
        [PARSER]
          Name regex
          Format regex
          Regex ^(?<time>[^ ]+) (?<stream>[^ ]+) (?<logtag>[^ ]+) (?<message>.+)$
          Time_Key time
          Time_Format %Y-%m-%dT%H:%M:%S.%L%z
          Time_Keep On
          Decode_Field_As json message
        
        EOT
      })
      "id" = "aws-observability/aws-logging"
      "immutable" = false
      "metadata" = tolist([
        {
          "annotations" = tomap({})
          "generate_name" = ""
          "generation" = 0
          "labels" = tomap({})
          "name" = "aws-logging"
          "namespace" = "aws-observability"
          "resource_version" = "764"
          "uid" = "ea32d79f-6b69-4caf-9c48-96e148b44adc"
        },
      ])
    },
  ]
  "iam_policy" = [
    {
      "arn" = "arn:aws:iam::xxxxxxxxxxxxx:policy/fargate-fargate-fluentbit-logs-20231101194545414700000009"
      "description" = ""
      "id" = "arn:aws:iam::xxxxxxxxxxxxx:policy/fargate-fargate-fluentbit-logs-20231101194545414700000009"
      "name" = "fargate-fargate-fluentbit-logs-20231101194545414700000009"
      "name_prefix" = "fargate-fargate-fluentbit-logs-"
      "path" = "/"
      "policy" = "{\"Statement\":[{\"Action\":[\"logs:PutLogEvents\",\"logs:DescribeLogStreams\",\"logs:CreateLogStream\",\"logs:CreateLogGroup\"],\"Effect\":\"Allow\",\"Resource\":[\"arn:aws:logs:us-west-2:978045894046:log-group:/fargate/fargate-fluentbit-logs20231101194544512300000008:logstream:*\",\"arn:aws:logs:us-west-2:978045894046:log-group:/fargate/fargate-fluentbit-logs20231101194544512300000008:*\"],\"Sid\":\"PutLogEvents\"}],\"Version\":\"2012-10-17\"}"
      "policy_id" = "ANPA6HOAT7WPIDPJNSQ6V"
      "tags" = tomap({})
      "tags_all" = tomap({})
    },
  ]
}
```
