### PR TITLE
feat: Grant IAM policy permissions to allow Fargate Fluent Bit to send logs to Kinesis Data Firehose

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2540,7 +2540,7 @@ data "aws_iam_policy_document" "fargate_fluentbit" {
   }
 
   dynamic "statement" {
-    for_each = length(lookup(var.fargate_fluentbit, "data_firehose_arns", [])) > 0 ? [1] : []
+    for_each = try(var.fargate_fluentbit.send_to_firehose, false) ? [1] : []
 
     content {
       sid = "FirehoseEvent"

--- a/main.tf
+++ b/main.tf
@@ -2545,11 +2545,11 @@ data "aws_iam_policy_document" "fargate_fluentbit" {
     content {
       sid = "FirehoseEvent"
       actions = [
-          "firehose:PutRecordBatch"
+        "firehose:PutRecordBatch"
       ]
-      resources = lookup(var.fargate_fluentbit, "firehose_arns", ["*"]) 
+      resources = lookup(var.fargate_fluentbit, "firehose_arns", ["*"])
     }
-}
+  }
 }
 # Help on Fargate Logging with Fluentbit and CloudWatch
 # https://docs.aws.amazon.com/eks/latest/userguide/fargate-logging.html

--- a/main.tf
+++ b/main.tf
@@ -2538,8 +2538,20 @@ data "aws_iam_policy_document" "fargate_fluentbit" {
       resources = var.fargate_fluentbit.s3_bucket_arns
     }
   }
-}
 
+  dynamic "statement" {
+    for_each = length(lookup(var.fargate_fluentbit, "data_firehose_arns", [])) > 0 ? [1] : []
+
+    content {
+      sid = "FirehoseEvent"
+      actions = [
+         "firehose:PutRecord",
+          "firehose:PutRecordBatch"
+      ]
+      resources = var.fargate_fluentbit.data_firehose_arns
+    }
+}
+}
 # Help on Fargate Logging with Fluentbit and CloudWatch
 # https://docs.aws.amazon.com/eks/latest/userguide/fargate-logging.html
 resource "kubernetes_namespace_v1" "aws_observability" {

--- a/main.tf
+++ b/main.tf
@@ -2545,7 +2545,6 @@ data "aws_iam_policy_document" "fargate_fluentbit" {
     content {
       sid = "FirehoseEvent"
       actions = [
-         "firehose:PutRecord",
           "firehose:PutRecordBatch"
       ]
       resources = lookup(var.fargate_fluentbit, "firehose_arns", ["*"]) 

--- a/main.tf
+++ b/main.tf
@@ -2548,7 +2548,7 @@ data "aws_iam_policy_document" "fargate_fluentbit" {
          "firehose:PutRecord",
           "firehose:PutRecordBatch"
       ]
-      resources = var.fargate_fluentbit.data_firehose_arns
+      resources = lookup(var.fargate_fluentbit, "firehose_arns", ["*"]) 
     }
 }
 }


### PR DESCRIPTION
### What does this PR do?
This pull request enables users to grant IAM policy permissions to allow Fargate Fluent Bit to send logs to Kinesis Data Firehose

### Motivation
I have encountered this issue. My company requires me to send logs to Kinesis Data Firehose, and I implemented this solution through the aforementioned modification. - Resolves #118 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes
