### PR TITLE
feat: Extend more control over Karpenter permissions for 0.32+ changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2837,8 +2837,8 @@ data "aws_iam_policy_document" "karpenter" {
 
     condition {
       test     = "StringLike"
-      variable = "ec2:ResourceTag/Name"
-      values   = ["*karpenter*", "*compute.internal"]
+      variable = "ec2:ResourceTag/${try(var.karpenter.irsa_tag_key, "Name")}"
+      values   = try(var.karpenter.irsa_tag_values, ["*karpenter*", "*compute.internal", "*ec2.internal"])
     }
   }
 
@@ -2976,7 +2976,7 @@ resource "aws_iam_role_policy_attachment" "additional" {
 }
 
 resource "aws_iam_instance_profile" "karpenter" {
-  count = var.enable_karpenter && try(var.karpenter_node.create_instance_profile, true) && !var.karpenter_enable_instance_profile_creation ? 1 : 0
+  count = var.enable_karpenter && try(var.karpenter_node.create_instance_profile, true) ? 1 : 0
 
   name        = try(var.karpenter_node.iam_role_use_name_prefix, true) ? null : local.karpenter_node_iam_role_name
   name_prefix = try(var.karpenter_node.iam_role_use_name_prefix, true) ? "${local.karpenter_node_iam_role_name}-" : null


### PR DESCRIPTION
### What does this PR do?

- Extend more control over Karpenter permissions for 0.32+ changes
- Remove the doubly redundant `!var.karpenter_enable_instance_profile_creation` conditional on the Karpenter instance profile

### Motivation

- With this change, users now have the ability to change the permissions used by the Karpenter IRSA to something like:

```hcl
module "eks_blueprints_addons" {
  source = "aws-ia/eks-blueprints-addons/aws"
  
  ...
  enable_karpenter = true
  karpenter = {
    irsa_tag_key   = "aws:ResourceTag/karpenter.sh/nodepool"
    irsa_tag_value = "*" 
  }
}
```
- This change also extends the current value patterns for the `Name` tag value to include `*ec2.internal` which has been reported as another common name pattern
- The instance profile changes is meant to support users migrating from <= 0.31 to 0.32+ where Karpenter starts creating the instance profile that it will use. This change allows the current instance profile to stay around longer until users decide its safe to remove by using:
```hcl
module "eks_blueprints_addons" {
  source = "aws-ia/eks-blueprints-addons/aws"
  
  ...
  enable_karpenter = true
  karpenter_node = {
    create_instance_profile = false
  }
}
```
- Resolves #299
- Resolves #300
- Resolves #304
- Resolves #309

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
