### PR TITLE
fix: Restrict Karpenter privileges on AWS SSM parameter store

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2823,7 +2823,7 @@ data "aws_iam_policy_document" "karpenter" {
 
   statement {
     actions   = ["ssm:GetParameter"]
-    resources = ["arn:${local.partition}:ssm:${local.region}::parameter/*"]
+    resources = ["arn:${local.partition}:ssm:${local.region}::parameter/aws/service/*"]
   }
 
   statement {


### PR DESCRIPTION


### What does this PR do?

The [Karpenter documentation](https://karpenter.sh/docs/reference/cloudformation/#:~:text=Copy-,AllowSSMReadActions,-The%20AllowSSMReadActions%20Sid) references less privileges (AWS SSM Parameter Store read access) than what's implemented in the current addon module for karpenter. 

This PR reconciles the current terraform module with what the documentation states.

### Motivation

Follow the principle of least privilege

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?
