### PR TITLE
fix: Add karpenter iam policy sids

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2795,6 +2795,7 @@ data "aws_iam_policy_document" "karpenter" {
       "ec2:DescribeSubnets",
     ]
     resources = ["*"]
+    sid       = "AllowDescribeResources"
   }
 
   statement {
@@ -2809,6 +2810,7 @@ data "aws_iam_policy_document" "karpenter" {
       "arn:${local.partition}:ec2:${local.region}:${local.account_id}:*",
       "arn:${local.partition}:ec2:${local.region}::image/*"
     ]
+    sid = "AllowCreateResources"
   }
 
   statement {
@@ -2819,19 +2821,23 @@ data "aws_iam_policy_document" "karpenter" {
   statement {
     actions   = ["pricing:GetProducts"]
     resources = ["*"]
+    sid       = "AllowGetProducts"
   }
 
   statement {
     actions   = ["ssm:GetParameter"]
     resources = ["arn:${local.partition}:ssm:${local.region}::parameter/aws/service/*"]
+    sid       = "AllowGetSSMParameter"
   }
 
   statement {
     actions   = ["eks:DescribeCluster"]
     resources = ["arn:${local.partition}:eks:*:${local.account_id}:cluster/${var.cluster_name}"]
+    sid       = "AllowDescribeCluster"
   }
 
   statement {
+    sid       = "AllowTerminateInstances"
     actions   = ["ec2:TerminateInstances"]
     resources = ["arn:${local.partition}:ec2:${local.region}:${local.account_id}:instance/*"]
 
@@ -2853,6 +2859,7 @@ data "aws_iam_policy_document" "karpenter" {
         "sqs:ReceiveMessage",
       ]
       resources = [module.karpenter_sqs.queue_arn]
+      sid       = "AllowSQS"
     }
   }
 
@@ -2869,6 +2876,7 @@ data "aws_iam_policy_document" "karpenter" {
         "iam:TagInstanceProfile",
       ]
       resources = ["*"]
+      sid       = "AllowIAMInstanceProfileActions"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This is so that `source_policy_documents` or `override_policy_documents` can be used without appending new policies to the generated Karpenter policy document. If we can specify a sid, we can override the specific sid with the policy which we need.


### Motivation

<!-- What inspired you to submit this pull request? -->
In our environment we needed to modify `ec2:CreateFleet` to be a bit less restrictive, since the default policy only allows for modifications of resources within the same account. Since we have a setup where subnets are shared from another account, we need to modify that policy.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
