### PR TITLE
fix: Gateway-api-controller lacks permissions to create and describe required resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3564,7 +3564,14 @@ data "aws_iam_policy_document" "aws_gateway_api_controller" {
       "iam:CreateServiceLinkedRole",
       "ec2:DescribeVpcs",
       "ec2:DescribeSubnets",
-      "ec2:DescribeTags"
+      "ec2:DescribeTags",
+      "ec2:DescribeSecurityGroups",
+      "logs:CreateLogDelivery",
+      "logs:GetLogDelivery",
+      "logs:UpdateLogDelivery",
+      "logs:DeleteLogDelivery",
+      "logs:ListLogDeliveries",
+      "tag:GetResources"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
gateway-api-controller lacks permissions to do its job

### What does this PR do?

The api gateway controller addon lacks permissions to create httproutes as it currently throwing up errors 

```shell
{"level":"debug","ts":"2023-12-06T23:49:12.024Z","logger":"controller.route","caller":"lattice/target_group_synthesizer.go:81","msg":"Failed TargetGroupManager.Upsert k8s-default-parking due to AccessDeniedException: User: arn:aws:sts::331334982285:assumed-role/aws-gateway-api-controller-20231206231429634800000015/1701904568794509513 is not authorized to perform: tag:GetResources because no identity-based policy allows the tag:GetResources action\n\tstatus code: 400, request id: 884a076d-a781-49e3-8404-7236d80533bd"}
{"level":"debug","ts":"2023-12-06T23:49:12.102Z","logger":"cloud","caller":"aws/cloud.go:58","msg":"error","error":"AccessDeniedException: User: arn:aws:sts::331334982285:assumed-role/aws-gateway-api-controller-20231206231429634800000015/1701904568794509513 is not authorized to perform: tag:GetResources because no identity-based policy allows the tag:GetResources action\n\tstatus code: 400, request id: 91f30cbb-00f1-4e8f-b0ca-1de568aa0f2a","serviceName":"tagging","operation":"GetResources","params":"{\n  ResourceTypeFilters: [\"vpc-lattice:targetgroup\"],\n  TagFilters: [\n    {\n      Key: \"application-networking.k8s.aws/ServiceNamespace\",\n      Values: [\"default\"]\n    },\n    {\n      Key: \"application-networking.k8s.aws/SourceTypeKey\",\n      Values: [\"HTTPRoute\"]\n    },\n    {\n      Key: \"application-networking.k8s.aws/ProtocolVersion\",\n      Values: [\"HTTP1\"]\n    },\n    {\n      Key: \"application-networking.k8s.aws/RouteName\",\n      Values: [\"rates\"]\n    },\n    {\n      Key: \"application-networking.k8s.aws/RouteNamespace\",\n      Values: [\"default\"]\n    },\n    {\n      Key: \"application-networking.k8s.aws/ClusterName\",\n      Values: [\"cluster1\"]\n    },\n    {\n      Key: \"a
```
as it turns out that it lacks few more permissions to do its job as  deduced from the official [documentation](https://www.gateway-api-controller.eks.aws.dev/guides/deploy/ ) 


🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #328 328

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [x] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
