### PR TITLE
fix: Adding support for the default namespace service account to access AWS Secret Manager

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2325,6 +2325,7 @@ module "external_dns" {
 locals {
   external_secrets_service_account = try(var.external_secrets.service_account_name, "external-secrets-sa")
   external_secrets_namespace       = try(var.external_secrets.namespace, "external-secrets")
+  external_secrets_service_account_namespace = try(var.external_secrets.service_account_namespace, "external-secrets")
 }
 
 data "aws_iam_policy_document" "external_secrets" {
@@ -2462,7 +2463,7 @@ module "external_secrets" {
   oidc_providers = {
     this = {
       provider_arn = local.oidc_provider_arn
-      # namespace is inherited from chart
+      namespace = local.external_secrets_service_account_namespace
       service_account = local.external_secrets_service_account
     }
   }


### PR DESCRIPTION
### What does this PR do?
we could modify the namespace of the oidc_providers service account to a custom namespace that the user can specify when using external_secrets. This way, the SecretStore can utilize that service account to access AWS Secret Manager.

### Motivation
- Resolves #337 

### More

- [✔️](https://emojipedia.org/check-mark) ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [✔️](https://emojipedia.org/check-mark)] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

