### PR TITLE
fix: Change Karpenter instance termination key condition to use more broadly applciable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.5
+    rev: v1.86.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/docs/addons/karpenter.md
+++ b/docs/addons/karpenter.md
@@ -46,27 +46,28 @@ fargate-ip-10-0-45-112.us-west-2.compute.internal   Ready    <none>   2m33s   v1
 
 ```sh
 kubectl apply -f - <<EOF
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-    name: inflate
+  name: inflate
 spec:
-    replicas: 0
-    selector:
+  replicas: 0
+  selector:
     matchLabels:
-        app: inflate
-    template:
+      app: inflate
+  template:
     metadata:
-        labels:
+      labels:
         app: inflate
     spec:
-        terminationGracePeriodSeconds: 0
-        containers:
+      terminationGracePeriodSeconds: 0
+      containers:
         - name: inflate
-            image: public.ecr.aws/eks-distro/kubernetes/pause:3.7
-            resources:
+          image: public.ecr.aws/eks-distro/kubernetes/pause:3.7
+          resources:
             requests:
-                cpu: 1
+              cpu: 1
 EOF
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -2848,8 +2848,8 @@ data "aws_iam_policy_document" "karpenter" {
 
     condition {
       test     = "StringLike"
-      variable = "ec2:ResourceTag/${try(var.karpenter.irsa_tag_key, "Name")}"
-      values   = try(var.karpenter.irsa_tag_values, ["*karpenter*", "*compute.internal", "*ec2.internal"])
+      variable = "ec2:ResourceTag/kubernetes.io/cluster/${var.cluster_name}"
+      values   = ["*"]
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

- Change Karpenter instance termination key condition to use more broadly applciable

### Motivation

- On later versions  of karpenter (0.32+), the nodes are named by karpenter which can create conflicts with the current policy. Previous attempts to add additional name pattern globs as well as let users pass in both key and values to suite are still creating friction. Using this tag, which has been around since pre 0.10 Karpenter, should remove that friction for user until the policy defined here is updated to match the upstream project

- Resolves #336
- Resolves #339

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
