### PR TITLE
fix: Correct spelling in the locals.ec2_events

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ locals {
         detail-type = ["AWS Health Event"]
       }
     }
-    spot_interupt = {
+    spot_interrupt = {
       name        = "SpotInterrupt"
       description = "EC2 spot instance interruption warning"
       event_pattern = {


### PR DESCRIPTION
### What does this PR do?

I will make corrections to find spelling mistakes.
I understand that this change only affects the identifiers of resources.

i recreated a PR to merge v2.0 branch ( #344 )

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #345 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

```
~/terraform-aws-eks-blueprints-addons$ pre-commit run -a
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for merge conflicts................................................Passed
detect private key.......................................................Passed
detect aws credentials...................................................Passed
Terraform fmt............................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
Terraform validate.......................................................Passed
```

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

The corrected word  affects  only resource id.

I confirmed the correct spelling.

```
$ terraform plan | grep "spot_interrupt"
  # aws_cloudwatch_event_rule.karpenter["spot_interrupt"] will be created
  # aws_cloudwatch_event_target.karpenter["spot_interrupt"] will be created

```

