### PR TITLE
feat: MTLS support for LB controller

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1184,6 +1184,7 @@ data "aws_iam_policy_document" "aws_load_balancer_controller" {
       "elasticloadbalancing:DescribeTargetGroupAttributes",
       "elasticloadbalancing:DescribeTargetHealth",
       "elasticloadbalancing:DescribeTags",
+      "elasticloadbalancing:DescribeTrustStores",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
### What does this PR do?
Adds the `elasticloadbalancing:DescribeTrustStores` IAM policy for the new mTLS feature in LB Controller introduced in [v2.7.0](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.7.0).

- [] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR