### PR TITLE
fix(karpenter): Pin to previous working chart version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3015,7 +3015,7 @@ module "karpenter" {
   namespace        = local.karpenter_namespace
   create_namespace = try(var.karpenter.create_namespace, true)
   chart            = try(var.karpenter.chart, "karpenter")
-  chart_version    = try(var.karpenter.chart_version, "0.35.0")
+  chart_version    = try(var.karpenter.chart_version, "v0.32.1")
   repository       = try(var.karpenter.repository, "oci://public.ecr.aws/karpenter")
   values           = try(var.karpenter.values, [])
 


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->
If already installed the upgrade, you may get an issue.

```
failed to get API group resources: unable to retrieve the complete list of server APIs: karpenter.sh/v1beta1: the server could not find the requested resource
```

To fix uninstall karpenter and reapply terraform
```bash
helm uninstall karpenter -n karpenter
```


### Motivation

<!-- What inspired you to submit this pull request? -->

Fixes #365

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
