### PR TITLE
fix: Correct cluster autoscaler version typo, use (correct) static service principal DNS suffix

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.3.0
+      - uses: amannn/action-semantic-pull-request@v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,9 +13,7 @@ permissions: read-all
 
 env:
   TERRAFORM_DOCS_VERSION: v0.16.0
-  TFSEC_VERSION: v1.28.1
-  TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
-  TFLINT_VERSION: v0.45.0
+  TFLINT_VERSION: v0.50.3
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
@@ -33,7 +31,7 @@ jobs:
 
       - name: Get root directories
         id: dirs
-        uses: clowdhaus/terraform-composite-actions/directories@v1.8.3
+        uses: clowdhaus/terraform-composite-actions/directories@v1.9.0
 
   preCommitMinVersions:
     name: Min TF pre-commit
@@ -49,7 +47,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: changes
         with:
           # We only need to check Terraform files for the current directory
@@ -59,27 +57,15 @@ jobs:
             src:
               - '${{ matrix.directory }}/*.tf'
 
-      - name: Config Terraform plugin cache
-        if: steps.changes.outputs.src== 'true'
-        run: mkdir --parents ${{ env.TERRAFORM_DOCS_VERSION }}
-
-      - name: Cache Terraform
-        uses: actions/cache@v3
-        if: steps.changes.outputs.src== 'true'
-        with:
-          path: ${{ env.TERRAFORM_DOCS_VERSION }}
-          key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
-          restore-keys: ${{ runner.os }}-terraform-
-
       - name: Terraform min/max versions
-        uses: clowdhaus/terraform-min-max@v1.2.7
+        uses: clowdhaus/terraform-min-max@v1.3.0
         if: steps.changes.outputs.src== 'true'
         id: minMax
         with:
           directory: ${{ matrix.directory }}
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.3
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory !=  '.' && steps.changes.outputs.src== 'true' }}
         with:
@@ -87,7 +73,7 @@ jobs:
           args: 'terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*'
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.3
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory ==  '.' && steps.changes.outputs.src== 'true' }}
         with:
@@ -105,32 +91,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: changes
         with:
           filters: |
             src:
               - '**/*.tf'
 
-      - name: Config Terraform plugin cache
-        if: steps.changes.outputs.src== 'true'
-        run: mkdir --parents ${{ env.TERRAFORM_DOCS_VERSION }}
-
-      - name: Cache Terraform
-        uses: actions/cache@v3
-        if: steps.changes.outputs.src== 'true'
-        with:
-          path: ${{ env.TF_PLUGIN_CACHE_DIR }}
-          key: ${{ runner.os }}-terraform-${{ hashFiles('**/.terraform.lock.hcl') }}
-          restore-keys: ${{ runner.os }}-terraform-
-
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.2.7
+        uses: clowdhaus/terraform-min-max@v1.3.0
         if: steps.changes.outputs.src== 'true'
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.3
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.9.0
         if: steps.changes.outputs.src== 'true'
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}

--- a/.github/workflows/stale-issue-pr.yaml
+++ b/.github/workflows/stale-issue-pr.yaml
@@ -14,7 +14,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@v9
         id: stale
         with:
           ascending: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.0
+    rev: v1.88.2
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,6 @@ resource "time_sleep" "this" {
 
 locals {
   account_id = data.aws_caller_identity.current.account_id
-  dns_suffix = data.aws_partition.current.dns_suffix
   partition  = data.aws_partition.current.partition
   region     = data.aws_region.current.name
 
@@ -990,7 +989,7 @@ data "aws_iam_policy_document" "aws_fsx_csi_driver" {
 
   statement {
     sid       = "AllowCreateServiceLinkedRoles"
-    resources = ["arn:${local.partition}:iam::*:role/aws-service-role/s3.data-source.lustre.fsx.${local.dns_suffix}/*"]
+    resources = ["arn:${local.partition}:iam::*:role/aws-service-role/s3.data-source.lustre.fsx.${data.aws_partition.current.dns_suffix}/*"]
 
     actions = [
       "iam:CreateServiceLinkedRole",
@@ -1007,7 +1006,7 @@ data "aws_iam_policy_document" "aws_fsx_csi_driver" {
     condition {
       test     = "StringLike"
       variable = "iam:AWSServiceName"
-      values   = ["fsx.${local.dns_suffix}"]
+      values   = ["fsx.amazonaws.com"]
     }
   }
 
@@ -1153,7 +1152,7 @@ data "aws_iam_policy_document" "aws_load_balancer_controller" {
     condition {
       test     = "StringEquals"
       variable = "iam:AWSServiceName"
-      values   = ["elasticloadbalancing.${local.dns_suffix}"]
+      values   = ["elasticloadbalancing.amazonaws.com"]
     }
   }
 
@@ -1531,8 +1530,8 @@ module "aws_node_termination_handler_sqs" {
         {
           type = "Service"
           identifiers = [
-            "events.${local.dns_suffix}",
-            "sqs.${local.dns_suffix}",
+            "events.amazonaws.com",
+            "sqs.amazonaws.com",
           ]
         }
       ]
@@ -1965,7 +1964,7 @@ locals {
     "1.26" = "v1.26.6"
     "1.27" = "v1.27.5"
     "1.28" = "v1.28.2"
-    "1.29" = "v1.20.0"
+    "1.29" = "v1.29.0"
   }
 }
 
@@ -2909,8 +2908,8 @@ module "karpenter_sqs" {
         {
           type = "Service"
           identifiers = [
-            "events.${local.dns_suffix}",
-            "sqs.${local.dns_suffix}",
+            "events.amazonaws.com",
+            "sqs.amazonaws.com",
           ]
         }
       ]
@@ -2950,7 +2949,7 @@ data "aws_iam_policy_document" "karpenter_assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = ["ec2.${local.dns_suffix}"]
+      identifiers = ["ec2.amazonaws.com"]
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

- Correct cluster autoscaler version typo
- Use the correctm static service principal DNS suffix; we changed this in the EKS module as well since service principals do not change their DNS suffix across partitions
	- [Ref 1](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/modules/karpenter/main.tf#L447-L448)
	- [Ref 2](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/1627231af669796669ce83e0a4672a7e6d94a0b3/main.tf#L371-L380)
- Remove Terraform cache in CI - not really adding much other than failing checks when lockfile is out of sync

### Motivation

- Resolves #369
- Resolves #371

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
