### PR TITLE
fix: Change default `external-secrets` port when addons are deployed on EKS Fargate to avoid port conflict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.0
+    rev: v1.88.2
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ module "eks" {
 | <a name="input_enable_cert_manager"></a> [enable\_cert\_manager](#input\_enable\_cert\_manager) | Enable cert-manager add-on | `bool` | `false` | no |
 | <a name="input_enable_cluster_autoscaler"></a> [enable\_cluster\_autoscaler](#input\_enable\_cluster\_autoscaler) | Enable Cluster autoscaler add-on | `bool` | `false` | no |
 | <a name="input_enable_cluster_proportional_autoscaler"></a> [enable\_cluster\_proportional\_autoscaler](#input\_enable\_cluster\_proportional\_autoscaler) | Enable Cluster Proportional Autoscaler | `bool` | `false` | no |
+| <a name="input_enable_eks_fargate"></a> [enable\_eks\_fargate](#input\_enable\_eks\_fargate) | Identifies whether or not respective addons should be modified to support deployment on EKS Fargate | `bool` | `false` | no |
 | <a name="input_enable_external_dns"></a> [enable\_external\_dns](#input\_enable\_external\_dns) | Enable external-dns operator add-on | `bool` | `false` | no |
 | <a name="input_enable_external_secrets"></a> [enable\_external\_secrets](#input\_enable\_external\_secrets) | Enable External Secrets operator add-on | `bool` | `false` | no |
 | <a name="input_enable_fargate_fluentbit"></a> [enable\_fargate\_fluentbit](#input\_enable\_fargate\_fluentbit) | Enable Fargate FluentBit add-on | `bool` | `false` | no |

--- a/docs/addons/external-secrets.md
+++ b/docs/addons/external-secrets.md
@@ -17,7 +17,7 @@ You can optionally customize the Helm chart that deploys External Secrets via th
 
   external_secrets = {
     name          = "external-secrets"
-    chart_version = "0.8.1"
+    chart_version = "0.9.13"
     repository    = "https://charts.external-secrets.io"
     namespace     = "external-secrets"
     values        = [templatefile("${path.module}/values.yaml", {})]
@@ -33,3 +33,11 @@ external-secrets-67bfd5b47c-xc5xf                  1/1     Running   1 (2d1h ago
 external-secrets-cert-controller-8f75c6f79-qcfx4   1/1     Running   1 (2d1h ago)   2d6h
 external-secrets-webhook-78f6bd456-76wmm           1/1     Running   1 (2d1h ago)   2d6h
 ```
+
+## EKS Fargate
+
+By default, `external-secrets` creates a webhook pod that listens on port `10250` [[Reference](https://github.com/external-secrets/external-secrets/issues/1306#issuecomment-1171540600)]:
+
+> yes, by default we use port 10250 for the webhook pod because it's generally allowed throughout most default firewall implementations (GKE, EKS), but it conflicts with Fargate. Any port number should do the trick, as long as there is no sg rules or NACLs blocking it :).
+
+This module adds a value `enable_eks_fargate` which will change the webhook port from `10250` to `9443` which matches the [prior default value](https://github.com/external-secrets/external-secrets/issues/1078#issuecomment-1117077327) for `external-secrets` and is typically an acceptable port value within most clusters firewalls today.

--- a/main.tf
+++ b/main.tf
@@ -2437,6 +2437,10 @@ module "external_secrets" {
     {
       name  = "serviceAccount.name"
       value = local.external_secrets_service_account
+    },
+    {
+      name  = "webhook.port"
+      value = var.enable_eks_fargate ? "9443" : "10250"
     }],
     try(var.external_secrets.set, [])
   )

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,12 @@ variable "create_delay_dependencies" {
   default     = []
 }
 
+variable "enable_eks_fargate" {
+  description = "Identifies whether or not respective addons should be modified to support deployment on EKS Fargate"
+  type        = bool
+  default     = false
+}
+
 ################################################################################
 # (Generic) Helm Release
 ################################################################################


### PR DESCRIPTION
### What does this PR do?

- Change default `external-secrets` port when addons are deployed on EKS Fargate to avoid port conflict
	- Ref https://github.com/external-secrets/external-secrets/issues/1306#issuecomment-1171540600
	- Ref https://github.com/external-secrets/external-secrets/issues/1078#issuecomment-1117077327

### Motivation

- Resolves #55

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
