### PR TITLE
fix: Add support for gitops-bridge to argo events

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -242,6 +242,9 @@ module "argo_events" {
 
   create = var.enable_argo_events
 
+  # Disable helm release
+  create_release = var.create_kubernetes_resources
+
   # https://github.com/argoproj/argo-helm/tree/main/charts/argo-events
   name             = try(var.argo_events.name, "argo-events")
   description      = try(var.argo_events.description, "A Helm chart to install the Argo Events")


### PR DESCRIPTION
### What does this PR do?

- Add support for GitOps Bridge to Argo Events

### Motivation

- Resolves #377 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
