### PR TITLE
Karpenter - deploy in kube-system namespace

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2749,7 +2749,7 @@ locals {
   input_karpenter_node_instance_profile_name = try(var.karpenter_node.instance_profile_name, local.karpenter_node_iam_role_name)
   # This is the name passed to the Karpenter Helm chart - either the profile the module creates, or one provided by the user
   output_karpenter_node_instance_profile_name = try(aws_iam_instance_profile.karpenter[0].name, var.karpenter_node.instance_profile_name, "")
-  karpenter_namespace                         = try(var.karpenter.namespace, "karpenter")
+  karpenter_namespace                         = try(var.karpenter.namespace, "kube-system")
 
   karpenter_set = [
     # TODO - remove at next breaking change


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation
Since [v0.33](https://karpenter.sh/docs/upgrading/upgrade-guide/#upgrading-to-0330) it is recommended to deploy karpenter in the kube-system namespace
<!-- What inspired you to submit this pull request? -->
- Resolves #383 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
