### PR TITLE
feat: Added the varaible create_policy to allow users to create their own policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -538,6 +538,7 @@ module "aws_efs_csi_driver" {
   role_description              = try(var.aws_efs_csi_driver.role_description, "IRSA for aws-efs-csi-driver project")
   role_policies                 = lookup(var.aws_efs_csi_driver, "role_policies", {})
 
+  create_policy           = try(var.aws_efs_csi_driver.create_policy, true)
   source_policy_documents = data.aws_iam_policy_document.aws_efs_csi_driver[*].json
   policy_statements       = lookup(var.aws_efs_csi_driver, "policy_statements", [])
   policy_name             = try(var.aws_efs_csi_driver.policy_name, null)
@@ -730,6 +731,7 @@ module "aws_for_fluentbit" {
   role_description              = try(var.aws_for_fluentbit.role_description, "IRSA for aws-for-fluent-bit")
   role_policies                 = lookup(var.aws_for_fluentbit, "role_policies", {})
 
+  create_policy           = try(var.aws_for_fluentbit.create_policy, true)
   source_policy_documents = data.aws_iam_policy_document.aws_for_fluentbit[*].json
   policy_statements       = lookup(var.aws_for_fluentbit, "policy_statements", [])
   policy_name             = try(var.aws_for_fluentbit.policy_name, "aws-for-fluent-bit")
@@ -1111,6 +1113,7 @@ module "aws_fsx_csi_driver" {
   role_description              = try(var.aws_fsx_csi_driver.role_description, "IRSA for aws-fsx-csi-driver")
   role_policies                 = lookup(var.aws_fsx_csi_driver, "role_policies", {})
 
+  create_policy           = try(var.aws_fsx_csi_driver.create_policy, true)
   source_policy_documents = data.aws_iam_policy_document.aws_fsx_csi_driver[*].json
   policy_statements       = lookup(var.aws_fsx_csi_driver, "policy_statements", [])
   policy_name             = try(var.aws_fsx_csi_driver.policy_name, "aws-fsx-csi-driver")
@@ -1471,6 +1474,7 @@ module "aws_load_balancer_controller" {
   role_description              = try(var.aws_load_balancer_controller.role_description, "IRSA for aws-load-balancer-controller project")
   role_policies                 = lookup(var.aws_load_balancer_controller, "role_policies", {})
 
+  create_policy           = try(var.aws_load_balancer_controller.create_policy, true)
   source_policy_documents = data.aws_iam_policy_document.aws_load_balancer_controller[*].json
   policy_statements       = lookup(var.aws_load_balancer_controller, "policy_statements", [])
   policy_name             = try(var.aws_load_balancer_controller.policy_name, null)
@@ -1805,6 +1809,7 @@ module "aws_privateca_issuer" {
   role_description              = try(var.aws_privateca_issuer.role_description, "IRSA for AWS Private CA Issuer")
   role_policies                 = lookup(var.aws_privateca_issuer, "role_policies", {})
 
+  create_policy           = try(var.aws_privateca_issuer.create_policy, true)
   source_policy_documents = data.aws_iam_policy_document.aws_privateca_issuer[*].json
   policy_statements       = lookup(var.aws_privateca_issuer, "policy_statements", [])
   policy_name             = try(var.aws_privateca_issuer.policy_name, "aws-privateca-issuer")
@@ -2090,6 +2095,7 @@ module "cluster_autoscaler" {
   role_description              = try(var.cluster_autoscaler.role_description, "IRSA for cluster-autoscaler operator")
   role_policies                 = lookup(var.cluster_autoscaler, "role_policies", {})
 
+  create_policy           = try(var.cluster_autoscaler.create_policy, true)
   source_policy_documents = data.aws_iam_policy_document.cluster_autoscaler[*].json
   policy_statements       = lookup(var.cluster_autoscaler, "policy_statements", [])
   policy_name             = try(var.cluster_autoscaler.policy_name, null)
@@ -2458,6 +2464,7 @@ module "external_secrets" {
   role_description              = try(var.external_secrets.role_description, "IRSA for external-secrets operator")
   role_policies                 = lookup(var.external_secrets, "role_policies", {})
 
+  create_policy           = try(var.external_secrets.create_policy, true)
   source_policy_documents = data.aws_iam_policy_document.external_secrets[*].json
   policy_statements       = lookup(var.external_secrets, "policy_statements", [])
   policy_name             = try(var.external_secrets.policy_name, null)
@@ -3068,6 +3075,7 @@ module "karpenter" {
   role_description              = try(var.karpenter.role_description, "IRSA for Karpenter")
   role_policies                 = lookup(var.karpenter, "role_policies", {})
 
+  create_policy           = try(var.karpenter.create_policy, true)
   source_policy_documents = data.aws_iam_policy_document.karpenter[*].json
   policy_statements       = lookup(var.karpenter, "policy_statements", [])
   policy_name             = try(var.karpenter.policy_name, null)
@@ -3482,6 +3490,7 @@ module "velero" {
   role_description              = try(var.velero.role_description, "IRSA for Velero")
   role_policies                 = lookup(var.velero, "role_policies", {})
 
+  create_policy           = try(var.velero.create_policy, true)
   source_policy_documents = data.aws_iam_policy_document.velero[*].json
   policy_statements       = lookup(var.velero, "policy_statements", [])
   policy_name             = try(var.velero.policy_name, "velero")
@@ -3668,6 +3677,7 @@ module "aws_gateway_api_controller" {
   role_description              = try(var.aws_gateway_api_controller.role_description, "IRSA for aws-gateway-api-controller")
   role_policies                 = lookup(var.aws_gateway_api_controller, "role_policies", {})
 
+  create_policy           = try(var.aws_gateway_api_controller.create_policy, true)
   source_policy_documents = data.aws_iam_policy_document.aws_gateway_api_controller[*].json
   policy_statements       = lookup(var.aws_gateway_api_controller, "policy_statements", [])
   policy_name             = try(var.aws_gateway_api_controller.policy_name, null)


### PR DESCRIPTION
### What does this PR do?

This is an enchantment, Adding the create_policy variable to allow users to create and use their own policies. A faction already exists in addon module. 

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

Added the variable create_policy (true or false) for the following modules:
aws_efs_csi_driver
aws_for_fluentbit
aws_fsx_csi_driver
aws_privateca_issuer
aws_load_balancer_controller
aws_gateway_api_controller
cluster_proportional_autoscaler
external_secrets
velero

This will allow the users to attach their own policy without creating the preexisting one

### Motivation

I want to have the ability to allow the module to create the role but create my own policy
example usage:
```hctl
module "eks_blueprints_addons" {
  source  = "aws-ia/eks-blueprints-addons/aws"
  version = "~> 1.16"

  cluster_name      = module.eks.cluster_name
  cluster_endpoint  = module.eks.cluster_endpoint
  cluster_version   = module.eks.cluster_version
  oidc_provider_arn = module.eks.oidc_provider_arn

  # Using GitOps Bridge
  create_kubernetes_resources = false

  external_secrets = {
    create_policy = false
    role_policies = {
      external_secreat_policy = aws_iam_policy.external_secrets_irsa_policy.arn
    }
  }

  # EKS Blueprints Addons
  enable_cert_manager                 = local.aws_addons.enable_cert_manager
  enable_aws_efs_csi_driver           = local.aws_addons.enable_aws_efs_csi_driver
  enable_aws_fsx_csi_driver           = local.aws_addons.enable_aws_fsx_csi_driver
  enable_aws_cloudwatch_metrics       = local.aws_addons.enable_aws_cloudwatch_metrics
  enable_aws_privateca_issuer         = local.aws_addons.enable_aws_privateca_issuer
  enable_cluster_autoscaler           = local.aws_addons.enable_cluster_autoscaler
  enable_external_dns                 = local.aws_addons.enable_external_dns
  enable_external_secrets             = local.aws_addons.enable_external_secrets
  enable_aws_load_balancer_controller = local.aws_addons.enable_aws_load_balancer_controller
  enable_fargate_fluentbit            = local.aws_addons.enable_fargate_fluentbit
  enable_aws_for_fluentbit            = local.aws_addons.enable_aws_for_fluentbit
  enable_aws_node_termination_handler = local.aws_addons.enable_aws_node_termination_handler
  enable_karpenter                    = local.aws_addons.enable_karpenter
  enable_velero                       = local.aws_addons.enable_velero
  enable_aws_gateway_api_controller   = local.aws_addons.enable_aws_gateway_api_controller

  tags = local.tags
}
```
<!-- What inspired you to submit this pull request? -->
- Resolves #394

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
