### PR TITLE
fix: Switch to lazy evaluation for Karpenter node IAM role additional permissions attachment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
         args: ['--markdown-linebreak-ext=md']
@@ -11,7 +11,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.88.2
+    rev: v1.89.1
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/main.tf
+++ b/main.tf
@@ -2989,7 +2989,7 @@ resource "aws_iam_role_policy_attachment" "karpenter" {
 }
 
 resource "aws_iam_role_policy_attachment" "additional" {
-  for_each = { for k, v in try(var.karpenter_node.iam_role_additional_policies, {}) : k => v if local.create_karpenter_node_iam_role }
+  for_each = { for k, v in lookup(var.karpenter_node, "iam_role_additional_policies", {}) : k => v if local.create_karpenter_node_iam_role }
 
   policy_arn = each.value
   role       = aws_iam_role.karpenter[0].name


### PR DESCRIPTION
### What does this PR do?

- Change evaluation logic from eager (`try()`) to lazy (`lookup()`) to avoid unknown value errors when iterating over computed values https://github.com/clowdhaus/terraform-for-each-unknown

### Motivation

- Resolves #395

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
