### PR TITLE
feat: Create a KEDA deployment

### DIFF
--- a/docs/addons/keda.md
+++ b/docs/addons/keda.md
@@ -1,0 +1,37 @@
+# KEDA
+
+[KEDA](https://github.com/kedacore/charts/tree/main/keda) allows for fine grained autoscaling (including to/from zero) for event driven Kubernetes workloads. Serves as a Kubernetes Metrics Server and allows users to define autoscaling rules using a dedicated Kubernetes custom resource definition.
+
+
+## Usage
+
+KEDA can be deployed by enabling the add-on via the following.
+
+```hcl
+enable_keda = true
+```
+
+You can optionally customize the Helm chart that deploys KEDA via the following configuration.
+
+```hcl
+  enable_keda = true
+
+  keda = {
+    name          = "keda"
+    chart_version = "2.14.2"
+    repository    = "https://kedacore.github.io/charts"
+    namespace     = "keda"
+    values        = [templatefile("${path.module}/values.yaml", {})]
+  }
+```
+
+Verify keda pods are running.
+
+```sh
+$ kubectl get pods -n keda
+NAME                                               READY   STATUS    RESTARTS        AGE
+keda-admission-webhooks-68b4cfbb48-7z7w8           1/1     Running   0               2m22s
+keda-operator-647b44c8bb-wjb6g                     1/1     Running   0   
+2m22s
+keda-operator-metrics-apiserver-5f945dc9f8-f7529   1/1     Running   0  
+2m22s

--- a/main.tf
+++ b/main.tf
@@ -3800,3 +3800,59 @@ module "bottlerocket_update_operator" {
   # https://github.com/bottlerocket-os/bottlerocket-update-operator/tree/develop/deploy/charts/bottlerocket-update-operator
   depends_on = [module.bottlerocket_shadow]
 }
+
+################################################################################
+# KEDA: Kubernetes Event-driven Autoscaling
+################################################################################
+
+module "keda" {
+  source  = "aws-ia/eks-blueprints-addon/aws"
+  version = "1.1.1"
+
+  create = var.enable_keda
+
+  # Disable helm release
+  create_release = var.create_kubernetes_resources
+
+  # https://github.com/kedacore/charts/tree/main/keda/Chart.yaml
+  name             = try(var.keda.name, "keda")
+  description      = try(var.keda.description, "A Helm chart to install the KEDA")
+  namespace        = try(var.keda.namespace, "keda ")
+  create_namespace = try(var.keda.create_namespace, true)
+  chart            = try(var.keda.chart, "keda")
+  chart_version    = try(var.keda.chart_version, "2.14.2")
+  repository       = try(var.keda.repository, "https://kedacore.github.io/charts")
+  values           = try(var.keda.values, [])
+
+  timeout                    = try(var.keda.timeout, null)
+  repository_key_file        = try(var.keda.repository_key_file, null)
+  repository_cert_file       = try(var.keda.repository_cert_file, null)
+  repository_ca_file         = try(var.keda.repository_ca_file, null)
+  repository_username        = try(var.keda.repository_username, null)
+  repository_password        = try(var.keda.repository_password, null)
+  devel                      = try(var.keda.devel, null)
+  verify                     = try(var.keda.verify, null)
+  keyring                    = try(var.keda.keyring, null)
+  disable_webhooks           = try(var.keda.disable_webhooks, null)
+  reuse_values               = try(var.keda.reuse_values, null)
+  reset_values               = try(var.keda.reset_values, null)
+  force_update               = try(var.keda.force_update, null)
+  recreate_pods              = try(var.keda.recreate_pods, null)
+  cleanup_on_fail            = try(var.keda.cleanup_on_fail, null)
+  max_history                = try(var.keda.max_history, null)
+  atomic                     = try(var.keda.atomic, null)
+  skip_crds                  = try(var.keda.skip_crds, null)
+  render_subchart_notes      = try(var.keda.render_subchart_notes, null)
+  disable_openapi_validation = try(var.keda.disable_openapi_validation, null)
+  wait                       = try(var.keda.wait, false)
+  wait_for_jobs              = try(var.keda.wait_for_jobs, null)
+  dependency_update          = try(var.keda.dependency_update, null)
+  replace                    = try(var.keda.replace, null)
+  lint                       = try(var.keda.lint, null)
+
+  postrender    = try(var.keda.postrender, [])
+  set           = try(var.keda.set, [])
+  set_sensitive = try(var.keda.set_sensitive, [])
+
+  tags = var.tags
+}

--- a/variables.tf
+++ b/variables.tf
@@ -609,3 +609,19 @@ variable "create_kubernetes_resources" {
   type        = bool
   default     = true
 }
+
+################################################################################
+# KEDA: Kubernetes Event-driven Autoscaling
+################################################################################
+
+variable "enable_keda" {
+  description = "Enable KEDA"
+  type        = bool
+  default     = false
+}
+
+variable "keda" {
+  description = "KEDA add-on configurations"
+  type        = any
+  default     = {}
+}


### PR DESCRIPTION
### What does this PR do?

This PR introduces the implementation of KEDA (Kubernetes Event-Driven Autoscaling) to the EKS Blueprints Addons repository. KEDA enables event-driven autoscaling for Kubernetes workloads, supporting a wide range of scalers like AWS SQS, CloudWatch, and DynamoDB. The integration is achieved by adding a simple configuration option to enable KEDA.

### Motivation

The motivation behind this PR is to provide efficient resource utilization, enhance performance by dynamically adjusting workloads, and offer broad compatibility with various event sources.
- Resolves #245

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

In my local environment, KEDA successfully scaled applications based on event-driven triggers. 