### PR TITLE
feat: Adding Pod Identity / Access Entries option for Karpenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ module "eks" {
 | <a name="module_external_secrets"></a> [external\_secrets](#module\_external\_secrets) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
 | <a name="module_gatekeeper"></a> [gatekeeper](#module\_gatekeeper) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
 | <a name="module_ingress_nginx"></a> [ingress\_nginx](#module\_ingress\_nginx) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
+| <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | ../terraform-aws-eks-blueprints-addon | n/a |
 | <a name="module_karpenter_sqs"></a> [karpenter\_sqs](#module\_karpenter\_sqs) | terraform-aws-modules/sqs/aws | 4.0.1 |
 | <a name="module_kube_prometheus_stack"></a> [kube\_prometheus\_stack](#module\_kube\_prometheus\_stack) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
 | <a name="module_metrics_server"></a> [metrics\_server](#module\_metrics\_server) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
@@ -120,6 +120,7 @@ module "eks" {
 | [aws_cloudwatch_event_target.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_log_group.aws_for_fluentbit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.fargate_fluentbit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_eks_access_entry.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_access_entry) | resource |
 | [aws_eks_addon.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_iam_instance_profile.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_policy.fargate_fluentbit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -225,6 +226,7 @@ module "eks" {
 | <a name="input_helm_releases"></a> [helm\_releases](#input\_helm\_releases) | A map of Helm releases to create. This provides the ability to pass in an arbitrary map of Helm chart definitions to create | `any` | `{}` | no |
 | <a name="input_ingress_nginx"></a> [ingress\_nginx](#input\_ingress\_nginx) | Ingress Nginx add-on configurations | `any` | `{}` | no |
 | <a name="input_karpenter"></a> [karpenter](#input\_karpenter) | Karpenter add-on configuration values | `any` | `{}` | no |
+| <a name="input_karpenter_create_access_entry"></a> [karpenter\_create\_access\_entry](#input\_karpenter\_create\_access\_entry) | Determines whether to create Karpenter Access Entry for Cluster Access Management API. | `bool` | `false` | no |
 | <a name="input_karpenter_enable_instance_profile_creation"></a> [karpenter\_enable\_instance\_profile\_creation](#input\_karpenter\_enable\_instance\_profile\_creation) | Determines whether Karpenter will be allowed to create the IAM instance profile (v1beta1) or if Terraform will (v1alpha1) | `bool` | `true` | no |
 | <a name="input_karpenter_enable_spot_termination"></a> [karpenter\_enable\_spot\_termination](#input\_karpenter\_enable\_spot\_termination) | Determines whether to enable native node termination handling | `bool` | `true` | no |
 | <a name="input_karpenter_node"></a> [karpenter\_node](#input\_karpenter\_node) | Karpenter IAM role and IAM instance profile configuration values | `any` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -3096,14 +3096,14 @@ module "karpenter" {
   policy_name_use_prefix  = try(var.karpenter.policy_name_use_prefix, true)
   policy_path             = try(var.karpenter.policy_path, null)
   policy_description      = try(var.karpenter.policy_description, "IAM Policy for karpenter")
-  
+
   oidc_providers = {
     this = {
       provider_arn = local.oidc_provider_arn
       # namespace is inherited from chart
       service_account = local.karpenter_service_account_name
-    } 
-  } 
+    }
+  }
 
   tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -3022,9 +3022,8 @@ resource "aws_eks_access_entry" "node" {
 }
 
 module "karpenter" {
-  source = "../terraform-aws-eks-blueprints-addon"
-  # source  = "aws-ia/eks-blueprints-addon/aws"
-  # version = "1.1.1"
+  source  = "aws-ia/eks-blueprints-addon/aws"
+  version = "1.1.1"
 
   create = var.enable_karpenter
 

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -81,7 +81,7 @@ module "eks_blueprints_addons" {
     vpc-cni = {
       most_recent = true
     }
-    kube-proxy = {}
+    kube-proxy             = {}
     eks-pod-identity-agent = {}
     adot = {
       most_recent              = true
@@ -164,7 +164,7 @@ module "eks_blueprints_addons" {
   enable_karpenter                           = true
   karpenter_enable_instance_profile_creation = true
   karpenter_create_access_entry              = true
-   karpenter = {
+  karpenter = {
     enable_pod_identity             = true
     create_pod_identity_association = true
     # ECR login required
@@ -307,7 +307,7 @@ module "vpc" {
 
   private_subnet_tags = {
     "kubernetes.io/role/internal-elb" = 1
-    "karpenter.sh/discovery" = local.name
+    "karpenter.sh/discovery"          = local.name
   }
 
   tags = local.tags

--- a/variables.tf
+++ b/variables.tf
@@ -454,6 +454,12 @@ variable "karpenter_enable_instance_profile_creation" {
   default     = true
 }
 
+variable "karpenter_create_access_entry" {
+  description = "Determines whether to create Karpenter Access Entry for Cluster Access Management API."
+  type        = bool
+  default     = false
+}
+
 variable "karpenter_sqs" {
   description = "Karpenter SQS queue for native node termination handling configuration values"
   type        = any


### PR DESCRIPTION
### What does this PR do?

Enables Pod Identity and Access Entry feature for Karpenter addon.

* Adding variable to create Karpenter access entry.
* Changed the tests/complete 
  * Use Pod Identity provided by the https://github.com/aws-ia/terraform-aws-eks-blueprints-addon module.
  * Adding Pod Identity Addon
  * Adding tags for Karpenter discovery
* Updating Karpenter namespace to `kube-system`, as recommended since [v0.33](https://karpenter.sh/preview/upgrading/upgrade-guide/#upgrading-to-0330)

**TO DO: Change the "aws-ia/eks-blueprints-addon/aws" to the version supporting Pod Identity, `pre-commit` checks will not pass without that.**

### Motivation

Pod Identity and Access Entries aims to be the default options for granting permissions to addons. We should adopt this in the v2.

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

````
Apply complete! Resources: 125 added, 0 changed, 0 destroyed.

Outputs:

configure_kubectl = "aws eks --region us-west-2 update-kubeconfig --name complete"
$ terraform output -raw configure_kubectl | bash
Updated context arn:aws:eks:us-west-2:123456789012:cluster/complete in .kube/config
$ kubectl get pods -A
NAMESPACE                       NAME                                            READY   STATUS    RESTARTS      AGE
aws-node-termination-handler    aws-node-termination-handler-77466dbf55-9l5hh   1/1     Running   0             15m
cert-manager                    cert-manager-6d988558d6-p2vkg                   1/1     Running   0             15m
cert-manager                    cert-manager-cainjector-6976895488-dz5kx        1/1     Running   0             15m
cert-manager                    cert-manager-webhook-fcf48cc54-f8nvv            1/1     Running   0             15m
kube-system                     aws-node-2295k                                  2/2     Running   0             14m
kube-system                     aws-node-6grmt                                  2/2     Running   0             14m
kube-system                     aws-node-7bg5t                                  2/2     Running   0             14m
kube-system                     aws-node-cnswh                                  2/2     Running   0             14m
kube-system                     aws-node-gqjn9                                  2/2     Running   0             14m
kube-system                     aws-node-j467q                                  2/2     Running   0             14m
kube-system                     coredns-848555ff5-5s8mn                         1/1     Running   0             14m
kube-system                     coredns-848555ff5-8x6m8                         1/1     Running   0             14m
kube-system                     ebs-csi-controller-8489858766-b2s9h             6/6     Running   0             14m
kube-system                     ebs-csi-controller-8489858766-txtcf             6/6     Running   0             14m
kube-system                     ebs-csi-node-2kzsp                              3/3     Running   0             14m
kube-system                     ebs-csi-node-45q6k                              3/3     Running   0             14m
kube-system                     ebs-csi-node-4p9ng                              3/3     Running   0             14m
kube-system                     ebs-csi-node-jpcbx                              3/3     Running   0             14m
kube-system                     ebs-csi-node-kslkm                              3/3     Running   0             14m
kube-system                     ebs-csi-node-v5vpn                              3/3     Running   0             14m
kube-system                     eks-pod-identity-agent-6b9st                    1/1     Running   0             14m
kube-system                     eks-pod-identity-agent-725k6                    1/1     Running   0             14m
kube-system                     eks-pod-identity-agent-7lbvf                    1/1     Running   0             14m
kube-system                     eks-pod-identity-agent-g562k                    1/1     Running   0             14m
kube-system                     eks-pod-identity-agent-pq59j                    1/1     Running   0             14m
kube-system                     eks-pod-identity-agent-pw54s                    1/1     Running   0             14m
kube-system                     karpenter-545f7bd6cd-b2rm5                      1/1     Running   0             15m
kube-system                     karpenter-545f7bd6cd-hrckk                      1/1     Running   1 (14m ago)   15m
kube-system                     kube-proxy-2dzjw                                1/1     Running   0             14m
kube-system                     kube-proxy-47lqc                                1/1     Running   0             14m
kube-system                     kube-proxy-kwxlk                                1/1     Running   0             14m
kube-system                     kube-proxy-lf7ms                                1/1     Running   0             14m
kube-system                     kube-proxy-tctgd                                1/1     Running   0             14m
kube-system                     kube-proxy-vwgkl                                1/1     Running   0             14m
kube-system                     metrics-server-5dc9dbbd5b-x5r8m                 1/1     Running   0             15m

$ kubectl apply -f example.yaml
ec2nodeclass.karpenter.k8s.aws/default created
nodepool.karpenter.sh/default created
deployment.apps/inflate created

$ kubectl scale deploy/inflate --replicas 100

$ terraform destroy -auto-approve
Destroy complete! Resources: 125 destroyed.

$ pre-commit run --files tests/complete/*
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check for merge conflicts................................................Passed
detect private key.......................................................Passed
detect aws credentials...................................................Passed
Terraform fmt............................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
Terraform validate.......................................................Passed
$ pre-commit run --files *               
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check for merge conflicts................................................Passed
detect private key.......................................................Passed
detect aws credentials...................................................Passed
Terraform fmt............................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
Terraform validate.......................................................Passed
```

