### PR TITLE
feat: Update Karpenter default version to `0.37.0`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3021,7 +3021,7 @@ module "karpenter" {
   namespace        = local.karpenter_namespace
   create_namespace = try(var.karpenter.create_namespace, true)
   chart            = try(var.karpenter.chart, "karpenter")
-  chart_version    = try(var.karpenter.chart_version, "0.35.0")
+  chart_version    = try(var.karpenter.chart_version, "0.37.0")
   repository       = try(var.karpenter.repository, "oci://public.ecr.aws/karpenter")
   values           = try(var.karpenter.values, [])
 


### PR DESCRIPTION
### What does this PR do?

Update default version to [v0.37.0](https://github.com/aws/karpenter-provider-aws/releases/tag/v0.37.0)

<!-- A brief description of the change being made with this pull request. -->

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [x] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
