### PR TITLE
Do not fetch versions of the add-on if an explicit version is specified

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2169,7 +2169,7 @@ module "cluster_proportional_autoscaler" {
 ################################################################################
 
 data "aws_eks_addon_version" "this" {
-  for_each = var.eks_addons
+  for_each = { for k, v in var.eks_addons : k => v if try(v.addon_version == null, true) }
 
   addon_name         = try(each.value.name, each.key)
   kubernetes_version = var.cluster_version


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

### Motivation

Broken add-on metadata on the AWS side.
```
Error: reading EKS Add-On version info (aws_ebs_csi_driver, 1.30): empty result
```

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [x] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
