### PR TITLE
feat: Update IAM policy for AWS Load Balancer Controller to support Listener Attributes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1185,6 +1185,7 @@ data "aws_iam_policy_document" "aws_load_balancer_controller" {
       "elasticloadbalancing:DescribeTargetHealth",
       "elasticloadbalancing:DescribeTags",
       "elasticloadbalancing:DescribeTrustStores",
+      "elasticloadbalancing:DescribeListenerAttributes",
     ]
     resources = ["*"]
   }
@@ -1348,6 +1349,7 @@ data "aws_iam_policy_document" "aws_load_balancer_controller" {
       "elasticloadbalancing:ModifyTargetGroup",
       "elasticloadbalancing:ModifyTargetGroupAttributes",
       "elasticloadbalancing:DeleteTargetGroup",
+      "elasticloadbalancing:ModifyListenerAttributes",
     ]
     resources = ["*"]
 


### PR DESCRIPTION
### What does this PR do?

Add support for the latest version of the aws-load-balancer-controller v2.9.0.
See this commit for the IAM changes: https://github.com/kubernetes-sigs/aws-load-balancer-controller/commit/174ad832de5b7a960a3f88b50ee139b80f75190b#diff-18d547fa3761f3fd92e3c94aced34137247a3ebd73b3f547491dffc10859b712R43

### Motivation

Add support for aws-load-balancer-controller [v2.9.0](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.9.0)

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes
