### PR TITLE
docs: Correct namespace for kube-prometheus-stack

### DIFF
--- a/docs/addons/kube-prometheus-stack.md
+++ b/docs/addons/kube-prometheus-stack.md
@@ -27,7 +27,7 @@ You can optionally customize the Helm chart that deploys Kube Prometheus Stack v
 Verify kube-prometheus-stack pods are running.
 
 ```sh
-$ kubectl get pods -n external-secrets
+$ kubectl get pods -n kube-prometheus-stack
 NAME                                                        READY   STATUS    RESTARTS       AGE
 alertmanager-kube-prometheus-stack-alertmanager-0           2/2     Running   3 (2d2h ago)   2d7h
 kube-prometheus-stack-grafana-5c6cf88fd9-8wc9k              3/3     Running   3 (2d2h ago)   2d7h


### PR DESCRIPTION
### What does this PR do?

Add correct namespace for kube-prometheus-stack doc

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves: fix namespace for kube-prometheus-stack before the namespace was external-secrets

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
