### PR TITLE
fix: Add random entryopy to CloudFormation stack name for when module used multiple times on the same cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ module "eks" {
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.9 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.20 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
 
 ## Providers
@@ -80,6 +81,7 @@ module "eks" {
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.9 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.20 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.9 |
 
 ## Modules
@@ -140,6 +142,7 @@ module "eks" {
 | [kubernetes_config_map_v1.aws_logging](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1) | resource |
 | [kubernetes_config_map_v1_data.aws_for_fluentbit_containerinsights](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1_data) | resource |
 | [kubernetes_namespace_v1.aws_observability](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
+| [random_bytes.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/bytes) | resource |
 | [time_sleep.this](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_eks_addon_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_addon_version) | data source |

--- a/main.tf
+++ b/main.tf
@@ -3819,10 +3819,14 @@ module "bottlerocket_update_operator" {
 # Usage Telemetry
 ################################################################################
 
+resource "random_bytes" "this" {
+  length = 2
+}
+
 resource "aws_cloudformation_stack" "usage_telemetry" {
   count = var.observability_tag != null ? 1 : 0
 
-  name = var.cluster_name
+  name = "${var.cluster_name}-${random_bytes.this.hex}"
 
   on_failure = "DO_NOTHING"
   template_body = jsonencode({

--- a/versions.tf
+++ b/versions.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = ">= 2.20"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
     time = {
       source  = "hashicorp/time"
       version = ">= 0.9"


### PR DESCRIPTION
### What does this PR do?

- Add random entryopy to CloudFormation stack name for when module used multiple times on the same cluster

### Motivation

- Relates to #424 

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
