### PR TITLE
fix: Raise min required version of `hashicorp/random` provider to `v3.6`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ module "eks" {
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.9 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.20 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
 
 ## Providers
@@ -81,7 +81,7 @@ module "eks" {
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.9 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.20 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.6 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.9 |
 
 ## Modules

--- a/versions.tf
+++ b/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = ">= 3.6"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
It's due to this error:

The provider hashicorp/random does not support resource type "random_bytes"

PR that introduced this scenario:
https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/pull/425

Random provider documentation:
https://registry.terraform.io/providers/hashicorp/random/3.6.0/docs

### What does this PR do?

Just bump the required hashicorp/random provider to request at least version `3.6.0` to support  the `random_bytes` resource.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #426

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X] Yes, I ran `pre-commit run -a` with this PR

```sh
Initializing provider plugins...
- terraform.io/builtin/terraform is built in to Terraform
- Finding hashicorp/random versions matching ">= 3.6.0, ~> 3.6.0"...
...
- Installing hashicorp/random v3.6.3...
- Installed hashicorp/random v3.6.3 (signed by HashiCorp)
...
Terraform has been successfully initialized!
```

`pre-commit run -a`
``` 
$ pre-commit run -a
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check for merge conflicts................................................Passed
detect private key.......................................................Passed
detect aws credentials...................................................Passed
Terraform fmt............................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
Terraform validate.......................................................Passed
```
### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
