### PR TITLE
fix: Attempt to use created log group for AWS for FluentBit before falling back to an externally created log group name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -700,7 +700,7 @@ module "aws_for_fluentbit" {
     },
     {
       name  = "cloudWatchLogs.logGroupName"
-      value = local.aws_for_fluentbit_cw_log_group_name
+      value = aws_cloudwatch_log_group.aws_for_fluentbit.name
     },
     {
       name  = "cloudWatchLogs.logGroupTemplate"

--- a/main.tf
+++ b/main.tf
@@ -700,7 +700,7 @@ module "aws_for_fluentbit" {
     },
     {
       name  = "cloudWatchLogs.logGroupName"
-      value = aws_cloudwatch_log_group.aws_for_fluentbit.name
+      value = try(aws_cloudwatch_log_group.aws_for_fluentbit[0].name, local.aws_for_fluentbit_cw_log_group_name)
     },
     {
       name  = "cloudWatchLogs.logGroupTemplate"


### PR DESCRIPTION
### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

Change the `cloudWatchLogs.logGroupName` fluentbit helm chart value to match the created log group. Might not work if the log group doesn't exist, haven't tested this yet etc.

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #341 

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

I saw the [this closed PR](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/pull/409) also fixed the issue and also works when the log group doesn't exist.