### PR TITLE
feat: Add `ec2:GetSecurityGroupsForVpc` permission to `aws-load-balancer-controller`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1174,6 +1174,7 @@ data "aws_iam_policy_document" "aws_load_balancer_controller" {
       "ec2:DescribeTags",
       "ec2:GetCoipPoolUsage",
       "ec2:DescribeCoipPools",
+      "ec2:GetSecurityGroupsForVpc",
       "elasticloadbalancing:DescribeLoadBalancers",
       "elasticloadbalancing:DescribeLoadBalancerAttributes",
       "elasticloadbalancing:DescribeListeners",


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Update the policy document for AWS Load Balancer controller to support the latest version v.2.10.0.
See [kubernetes-sigs/aws-load-balancer-controller@`v2.9.2...v2.10.0`#diff-50bbcd5ae0](https://github.com/kubernetes-sigs/aws-load-balancer-controller/compare/v2.9.2...v2.10.0#diff-50bbcd5ae0a29cf3c9e0d5fb5f425bbf7aa961f68bce6133162bfb8ce4eff085R32)

### Motivation

Add support for aws-load-balancer-controller [v2.10.0](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.10.0)

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
