### PR TITLE
feat: add renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["regex"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)main\\.tf$"],
+      "matchStrings": [
+        "chart *=.*\"(?<depName>.*?)\"\\)\\s*chart_version *=.*\"(?<currentValue>.*?)\"\\)\\s*repository *=.*\"(?<registryUrl>.*?)\"\\)"
+      ],
+      "datasourceTemplate": "helm",
+      "versioningTemplate": "helm"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,18 @@
       "customType": "regex",
       "fileMatch": ["(^|/)main\\.tf$"],
       "matchStrings": [
-        "chart *=.*\"(?<depName>.*?)\"\\)\\s*chart_version *=.*\"(?<currentValue>.*?)\"\\)\\s*repository *=.*\"(?<registryUrl>.*?)\"\\)"
+        "chart *=.*\"(?<depName>.*?)\"\\)\\s*chart_version *=.*\"(?<currentValue>.*?)\"\\)\\s*repository *=.*\"(?<registryUrl>https.*?)\"\\)"
       ],
-      "datasourceTemplate": "helm",
-      "versioningTemplate": "helm"
+      "datasourceTemplate": "helm"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)main\\.tf$"],
+      "matchStrings": [
+        "chart *=.*\"(?<depName>.*?)\"\\)\\s*chart_version *=.*\"(?<currentValue>.*?)\"\\)\\s*repository *=.*\"oci://(?<namespace>.*?)\"\\)"
+      ],
+      "datasourceTemplate": "docker",
+      "packageNameTemplate": "{{namespace}}/{{depName}}"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
       "customType": "regex",
       "fileMatch": ["(^|/)main\\.tf$"],
       "matchStrings": [
-        "chart *=.*\"(?<depName>.*?)\"\\)\\s*chart_version *=.*\"(?<currentValue>.*?)\"\\)\\s*repository *=.*\"(?<registryUrl>https.*?)\"\\)"
+        "chart *=.*\"(?<depName>.*?)\"\\).*\\s+chart_version *=.*\"(?<currentValue>.*?)\"\\).*\\s+repository *=.*\"(?<registryUrl>https.*?)\"\\)"
       ],
       "datasourceTemplate": "helm"
     },
@@ -15,7 +15,7 @@
       "customType": "regex",
       "fileMatch": ["(^|/)main\\.tf$"],
       "matchStrings": [
-        "chart *=.*\"(?<depName>.*?)\"\\)\\s*chart_version *=.*\"(?<currentValue>.*?)\"\\)\\s*repository *=.*\"oci://(?<namespace>.*?)\"\\)"
+        "chart *=.*\"(?<depName>.*?)\"\\).*\\s+chart_version *=.*\"(?<currentValue>.*?)\"\\).*\\s+repository *=.*\"oci://(?<namespace>.*?)\"\\)"
       ],
       "datasourceTemplate": "docker",
       "packageNameTemplate": "{{namespace}}/{{depName}}"

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "enabledManagers": ["regex"],
+  "enabledManagers": ["custom.regex"],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This PR adds a `renovate.json` config file to automatically create PRs using [Renovate](https://github.com/renovatebot/renovate) for Helm chart version updates in `main.tf`.

The regex used in the config to match the chart versions can be validated here: https://regex101.com/r/MB6rrh/2

To make use of this config, install the [Renovate Cloud-Hosted App](https://github.com/apps/renovate) on your GitHub org, then select the repos to enable.

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #50 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->

The renovate config is setup to only use the regex manager. Other managers such as [terraform](https://docs.renovatebot.com/modules/manager/terraform/) can optionally be enabled to automatically create PRs for terraform module and provider updates.

Example pull requests created by Renovate for this project can be found here: https://github.com/calebhansard/terraform-aws-eks-blueprints-addons/pulls
