### PR TITLE
feat: Add `elasticloadbalancing:DescribeCapacityReservation` and `elasticloadbalancing:ModifyCapacityReservation` to `aws-load-balancer-controller`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1187,6 +1187,7 @@ data "aws_iam_policy_document" "aws_load_balancer_controller" {
       "elasticloadbalancing:DescribeTags",
       "elasticloadbalancing:DescribeTrustStores",
       "elasticloadbalancing:DescribeListenerAttributes",
+      "elasticloadbalancing:DescribeCapacityReservation",
     ]
     resources = ["*"]
   }
@@ -1351,6 +1352,7 @@ data "aws_iam_policy_document" "aws_load_balancer_controller" {
       "elasticloadbalancing:ModifyTargetGroupAttributes",
       "elasticloadbalancing:DeleteTargetGroup",
       "elasticloadbalancing:ModifyListenerAttributes",
+      "elasticloadbalancing:ModifyCapacityReservation",
     ]
     resources = ["*"]
 


### PR DESCRIPTION
### What does this PR do?

Add support for the latest aws-load-balancer-controller version 2.11.0.
See https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.11.0

### Motivation

Add support for aws-load-balancer-controller [v2.11.0](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.11.0)

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
