### PR TITLE
feat: Add `secretsmanager:BatchGetSecretValue` to support external-secrets bulk fetch

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2377,6 +2377,7 @@ data "aws_iam_policy_document" "external_secrets" {
         "secretsmanager:GetSecretValue",
         "secretsmanager:DescribeSecret",
         "secretsmanager:ListSecretVersionIds",
+        "secretsmanager:BatchGetSecretValue",
       ]
       resources = var.external_secrets_secrets_manager_arns
     }


### PR DESCRIPTION
### What does this PR do?

It adds support for external-secrets bulk fetch feature introduced in [v0.12.1](https://github.com/external-secrets/external-secrets/releases/tag/v0.12.1)

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
Support for external-secrets [v0.12.1](https://github.com/external-secrets/external-secrets/releases/tag/v0.12.1)

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
