### PR TITLE
fix: Document Fargate kubelet cert-manager port conflict

### DIFF
--- a/docs/addons/cert-manager.md
+++ b/docs/addons/cert-manager.md
@@ -13,6 +13,23 @@ module "eks_blueprints_addons" {
 }
 ```
 
+#### :warning: **Fargate kubelet port conflict** :warning:
+When running on Fargate the kubelet port conflicts with the secure webhook port cert-manager uses so you will need to change it.
+```hcl
+  # cert-manager default webhook port conflicts with the kubelet port on Fargate
+  # so we change it to avoid the conflict.
+  # SEE: https://github.com/cert-manager/cert-manager/issues/3237
+  enable_cert_manager = true
+  cert_manager = {
+    set = [
+      {
+        name  = "webhook.securePort"
+        value = 10260
+      },
+    ]
+  }
+```
+
 ### Helm Chart customization
 
 It's possible to customize your deployment using the Helm Chart parameters inside the `cert-manager` configuration block:


### PR DESCRIPTION
### What does this PR do?

Update documentation for the cert-manager addon to include a note about the Fargate kubelet port conflict with cert-manager webhook and how to fix it.

### Motivation

When testing a prototype on Fargate I ran into this issue. Document it so others will benefit.

### More

- [ *] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ *] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Documentation change only, I've validated that the documented fix works.