### PR TITLE
feat: Add policy path to fargate_fluentbit

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2508,6 +2508,7 @@ resource "aws_iam_policy" "fargate_fluentbit" {
 
   name        = try(var.fargate_fluentbit.policy_name_use_prefix, true) ? null : local.fargate_fluentbit_policy_name
   name_prefix = try(var.fargate_fluentbit.policy_name_use_prefix, true) ? try(var.fargate_fluentbit.policy_name_prefix, "${local.fargate_fluentbit_policy_name}-") : null
+  path        = try(var.fargate_fluentbit.policy_path, null)
   description = try(var.fargate_fluentbit.policy_description, null)
   policy      = data.aws_iam_policy_document.fargate_fluentbit[0].json
 }


### PR DESCRIPTION
### What does this PR do?

Adds `path` argument to `aws_iam_policy.fargate_fluentbit`.

### Motivation

I want to be able to provide a custom path for the `fargate_fluentbit` policy to adhere to security constraints within some organisations.

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Similar to https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/issues/96
