### PR TITLE
fix: Update cert-manager to use crds.enabled instead of the deprecated installCRDs option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1878,7 +1878,7 @@ module "cert_manager" {
   namespace        = local.cert_manager_namespace
   create_namespace = try(var.cert_manager.create_namespace, true)
   chart            = try(var.cert_manager.chart, "cert-manager")
-  chart_version    = try(var.cert_manager.chart_version, "v1.14.3")
+  chart_version    = try(var.cert_manager.chart_version, "v1.17.1")
   repository       = try(var.cert_manager.repository, "https://charts.jetstack.io")
   values           = try(var.cert_manager.values, [])
 
@@ -1911,7 +1911,11 @@ module "cert_manager" {
   postrender = try(var.cert_manager.postrender, [])
   set = concat([
     {
-      name  = "installCRDs"
+      name  = "crds.enabled"
+      value = true
+    },
+    {
+      name  = "crds.keep"
       value = true
     },
     {


### PR DESCRIPTION
### What does this PR do?

This is a follow-up to https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/pull/435.  

<strike>Instead of changing the option directly, we add a pre-check before setting `installCRDs`.</strike>

<strike>If the user has already set the new `crds.enabled` flag in either `values` or `set`, we do not add the deprecated `installCRDs` option.  </strike>

<strike>This helps prevent breaking changes and allows users to avoid the deprecated installCRDs option.</strike>

Update: Follow-up to https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/pull/443#pullrequestreview-2633785239

I have updated the PR to pump up the version of the cert-manager to the latest minor version.

I have also updated the PR to remove the usage of `installCRDs` and replaced it with both the new `crds.enabled` and `crds.keep` options.

### Motivation
- Resolves https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/issues/420

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
