### PR TITLE
feat: Update iam policy to support CapacityReservations with karpente…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2835,6 +2835,7 @@ data "aws_iam_policy_document" "karpenter" {
       "ec2:DescribeSecurityGroups",
       "ec2:DescribeSpotPriceHistory",
       "ec2:DescribeSubnets",
+      "ec2:DescribeCapacityReservations",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
### What does this PR do?

Be able to deploy karpenter with the capacityReservation feature

```
settings:
  featureGates:
    # -- reservedCapacity is ALPHA and is disabled by default.
    # Setting this will enable native on-demand capacity reservation support.
    reservedCapacity: true
```    

### Motivation

Resolve this error when karpenter deployment with reservedCapacity enabled

```
{"level":"ERROR","time":"2025-04-14T09:21:37.367Z","logger":"controller","message":"Reconciler error","commit":"ad71530","controller":"nodeclass","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","reconcileID":"108debf3-aeaf-4b11-966b-e9875942224b","error":"getting capacity reservations, listing capacity reservations, operation error EC2: DescribeCapacityReservations, https response error StatusCode: 403, RequestID: f5cbf65c-0fae-49db-bc17-95935e8af78e, api error UnauthorizedOperation: You are not authorized to perform this operation. User: arn:aws:sts::xxxxxxxxxxxx:assumed-role/karpenter-xxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxx is not authorized to perform: ec2:DescribeCapacityReservations because no identity-based policy allows the ec2:DescribeCapacityReservations action"}
```

### More

- [X] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?