### PR TITLE
docs: Update velero.md - update link url to stateful example/pattern

### DIFF
--- a/docs/addons/velero.md
+++ b/docs/addons/velero.md
@@ -32,7 +32,7 @@ velero = {
 }
 ```
 
-To see a working example, see the [`stateful`](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples/stateful) example blueprint.
+To see a working example, see the [`stateful`](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/patterns/stateful) example blueprint.
 
 ## Validate
 


### PR DESCRIPTION
Update stateful example link

### What does this PR do?
Update the incorrect url that links to the stateful blueprints example

### Motivation

Broken links in docs is an easy first contribution

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

I am not sure if testing is required to update the docs?
