### PR TITLE
fix: Pin Helm provider max supported version due to new major provider version breaking changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.96.1
+    rev: v1.99.4
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ module "eks" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.9 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.9, < 3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.20 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
@@ -79,7 +79,7 @@ module "eks" {
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.9 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.9, < 3.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.20 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.6 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.9 |

--- a/tests/complete/README.md
+++ b/tests/complete/README.md
@@ -34,7 +34,7 @@ terraform destroy
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.9 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.9, < 3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.20 |
 
 ## Providers

--- a/tests/complete/versions.tf
+++ b/tests/complete/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = ">= 2.9, < 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
### What does this PR do?

- Pin Helm provider max supported version due to new major provider version breaking changes

### Motivation

- Recent Helm v3.x introduces breaking changes, theres already a hotfix out https://github.com/hashicorp/terraform-provider-helm/releases. Supporting v3.x would require breaking changes to this module so for now, pinning should suffice

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
