### PR TITLE
feat: Configurable event patterns for NTH EventBridge rules for all ec2 events

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,34 +32,62 @@ locals {
     health_event = {
       name        = "HealthEvent"
       description = "AWS health event"
-      event_pattern = {
-        source      = ["aws.health"]
-        detail-type = ["AWS Health Event"]
-      }
+      event_pattern = merge(
+        {
+          source      = ["aws.health"]
+          detail-type = ["AWS Health Event"]
+        },
+        try(length(var.aws_node_termination_handler_asg_names) > 0 ? {
+          detail = {
+            AutoScalingGroupName = var.aws_node_termination_handler_asg_names
+          }
+        } : {}, {})
+      )
     }
     spot_interupt = {
       name        = "SpotInterrupt"
       description = "EC2 spot instance interruption warning"
-      event_pattern = {
-        source      = ["aws.ec2"]
-        detail-type = ["EC2 Spot Instance Interruption Warning"]
-      }
+      event_pattern = merge(
+        {
+          source      = ["aws.ec2"]
+          detail-type = ["EC2 Spot Instance Interruption Warning"]
+        },
+        try(length(var.aws_node_termination_handler_asg_names) > 0 ? {
+          detail = {
+            AutoScalingGroupName = var.aws_node_termination_handler_asg_names
+          }
+        } : {}, {})
+      )
     }
     instance_rebalance = {
       name        = "InstanceRebalance"
       description = "EC2 instance rebalance recommendation"
-      event_pattern = {
-        source      = ["aws.ec2"]
-        detail-type = ["EC2 Instance Rebalance Recommendation"]
-      }
+      event_pattern = merge(
+        {
+          source      = ["aws.ec2"]
+          detail-type = ["EC2 Instance Rebalance Recommendation"]
+        },
+        try(length(var.aws_node_termination_handler_asg_names) > 0 ? {
+          detail = {
+            AutoScalingGroupName = var.aws_node_termination_handler_asg_names
+          }
+        } : {}, {})
+      )
     }
     instance_state_change = {
       name        = "InstanceStateChange"
       description = "EC2 instance state-change notification"
-      event_pattern = {
-        source      = ["aws.ec2"]
-        detail-type = ["EC2 Instance State-change Notification"]
-      }
+      event_pattern = merge(
+        {
+          source      = ["aws.ec2"]
+          detail-type = ["EC2 Instance State-change Notification"]
+        },
+        try(length(var.aws_node_termination_handler_asg_names) > 0 ? {
+          detail = {
+            AutoScalingGroupName = var.aws_node_termination_handler_asg_names
+          }
+        } : {}, {})
+      )
     }
   }
 }


### PR DESCRIPTION
Expands on work done in [#454](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/pull/454)

### What does this PR do?
In PR [#454](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/pull/454) a variable was added to allow the end user to create a pattern on their `EC2 Instance-terminate Lifecycle Action`  eventbridge rule that is scoped to only their desired ASG. Without this, your event rules will receive and send events for every ASG in your account. Expanding on this work, I am re-using the ASG name variable to add patterns to the rest of the ec2 events. 

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Seeing errors on our NTH pods about nodes and ASGs it never should have seen events from.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes
plan output:
<img width="1454" height="218" alt="image" src="https://github.com/user-attachments/assets/daaced35-e48f-40c6-9f69-68e3a9394c9a" />
<img width="1406" height="224" alt="image" src="https://github.com/user-attachments/assets/1fb0e47f-d435-4c83-8392-21cd6c51de14" />
<img width="1330" height="220" alt="image" src="https://github.com/user-attachments/assets/a30739d9-fc5b-43ee-b4a8-010422bd493a" />
<img width="1395" height="214" alt="image" src="https://github.com/user-attachments/assets/5a1fd6d1-c9b3-4309-8128-106c3de513c8" />
<img width="1449" height="220" alt="image" src="https://github.com/user-attachments/assets/c36af117-c1b3-468b-af4f-0647e75dddc7" />
