### PR TITLE
fix: Update deprecated AWS region attribute

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "time_sleep" "this" {
 locals {
   account_id = data.aws_caller_identity.current.account_id
   partition  = data.aws_partition.current.partition
-  region     = data.aws_region.current.name
+  region     = data.aws_region.current.region
 
   # Threads the sleep resource into the module to make the dependency
   cluster_endpoint  = time_sleep.this.triggers["cluster_endpoint"]


### PR DESCRIPTION
Resolves a deprecation warning by changing `data.aws_region.current.name` to `data.aws_region.current.region` in `main.tf`.

Refer to the official documentation for details:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region
