### PR TITLE
fix: Updates loadbalancer controller policy to match upstream references

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1204,6 +1204,7 @@ data "aws_iam_policy_document" "aws_load_balancer_controller" {
       "ec2:DescribeCoipPools",
       "ec2:GetSecurityGroupsForVpc",
       "ec2:DescribeIpamPools",
+      "ec2:DescribeRouteTables",
       "elasticloadbalancing:DescribeLoadBalancers",
       "elasticloadbalancing:DescribeLoadBalancerAttributes",
       "elasticloadbalancing:DescribeListeners",


### PR DESCRIPTION
### What does this PR do?

Adds `ec2:DescribeRouteTables` to the load balancer controller policy

<!-- A brief description of the change being made with this pull request. -->

### Motivation

I reviewed the policies from the [iam-role-for-service-accounts-eks module](https://github.com/terraform-aws-modules/terraform-aws-iam/blob/master/modules/iam-role-for-service-accounts-eks/policies.tf#L944), as well as the policy document published by the [kubernetes sig for aws-load-balancer-controller](https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.13.4/docs/install/iam_policy.json). Noticed this repository was missing this one permission for this role, so figured I'd open a PR to add it.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
