### PR TITLE
fix: Correct IAM policy BatchGetSecretValue in external secrets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2407,7 +2407,10 @@ data "aws_iam_policy_document" "external_secrets" {
     for_each = length(var.external_secrets_secrets_manager_arns) > 0 ? [1] : []
 
     content {
-      actions   = ["secretsmanager:ListSecrets"]
+      actions = [
+        "secretsmanager:ListSecrets",
+        "secretsmanager:BatchGetSecretValue",
+      ]
       resources = ["*"]
     }
   }
@@ -2421,7 +2424,6 @@ data "aws_iam_policy_document" "external_secrets" {
         "secretsmanager:GetSecretValue",
         "secretsmanager:DescribeSecret",
         "secretsmanager:ListSecretVersionIds",
-        "secretsmanager:BatchGetSecretValue",
       ]
       resources = var.external_secrets_secrets_manager_arns
     }


### PR DESCRIPTION
### What does this PR do?

This fixes external-secrets use of `BatchGetSecretValue` by correcting the IAM policy in accordance with the [external-secrets documentation](https://external-secrets.io/v0.20.1/provider/aws-secrets-manager/#iam-policy) and [AWS docs](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_iam-policies.html#auth-and-access_examples_batch).

IAM permission `secretsmanager:BatchGetSecretValue` should be against resource `*` rather than the individual secret.

### Motivation

- Resolves #475

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?
