### PR TITLE
feat: ListInstanceProfiles permission to IAM policy for Karpenter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2948,6 +2948,7 @@ data "aws_iam_policy_document" "karpenter" {
         "iam:GetInstanceProfile",
         "iam:RemoveRoleFromInstanceProfile",
         "iam:TagInstanceProfile",
+        "iam:ListInstanceProfiles",
       ]
       resources = ["*"]
     }


### PR DESCRIPTION

### What does this PR do?

Adds the permission `iam:ListInstanceProfiles`to the Karpenter IAM role, required for karpenter 1.7.0+:
https://karpenter.sh/docs/upgrading/upgrade-guide/#upgrading-to-170

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/issues/478

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [X] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
