### PR TITLE
Update cluster_autoscaler helm chart

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2073,7 +2073,7 @@ module "cluster_autoscaler" {
   namespace        = local.cluster_autoscaler_namespace
   create_namespace = try(var.cluster_autoscaler.create_namespace, false)
   chart            = try(var.cluster_autoscaler.chart, "cluster-autoscaler")
-  chart_version    = try(var.cluster_autoscaler.chart_version, "9.35.0")
+  chart_version    = try(var.cluster_autoscaler.chart_version, "9.50.1")
   repository       = try(var.cluster_autoscaler.repository, "https://kubernetes.github.io/autoscaler")
   values           = try(var.cluster_autoscaler.values, [])
 


### PR DESCRIPTION
### What does this PR do?

With EKS v1.33 we have seen an issue where cluster_autoscaler wasn't working properly.

Upgrading the helm chart to the latest version fixed it and everything works fine. I guess the new helm chart should not break compatibility with older EKS versions while fixing the newer one.

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?
