### PR TITLE
fix: Replace deprecated aws_region.name attribute for AWS Provider v6 compatibility

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "time_sleep" "this" {
 locals {
   account_id = data.aws_caller_identity.current.account_id
   partition  = data.aws_partition.current.partition
-  region     = data.aws_region.current.name
+  region     = data.aws_region.current.id
 
   # Threads the sleep resource into the module to make the dependency
   cluster_endpoint  = time_sleep.this.triggers["cluster_endpoint"]


### PR DESCRIPTION
### What does this PR do?

Replaces deprecated `data.aws_region.current.name` with `data.aws_region.current.id` to fix AWS Provider v6 compatibility warnings.

### Motivation

AWS Provider v6 deprecated the `name` attribute in favor of `id`. This change eliminates deprecation warnings and ensures compatibility with future provider versions.

- Resolves #471

### More

- [x] Yes, I have tested the PR using my local account setup
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Tested with AWS Provider v6.13.0. The `id` attribute returns identical values to the deprecated `name` attribute, so this is a drop-in replacement with no behavioral changes.