### PR TITLE
fix: Updated deprecated data.aws_region.current.name 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "time_sleep" "this" {
 locals {
   account_id = data.aws_caller_identity.current.account_id
   partition  = data.aws_partition.current.partition
-  region     = data.aws_region.current.name
+  region     = data.aws_region.current.region
 
   # Threads the sleep resource into the module to make the dependency
   cluster_endpoint  = time_sleep.this.triggers["cluster_endpoint"]


### PR DESCRIPTION
### What does this PR do?
With the latest v6 AWS provider, `name` argument in `aws_region` data-source has been deprecated and replaced by `region`. At the moment it throws in the following warning:

> 
> Warning: Deprecated attribute
> 
> on .terraform/modules/eks_addons_infrastructure_clusters_euc1/main.tf line 21, in locals:
> 21:   region     = data.aws_region.current.name
>  
>  The attribute "name" is deprecated. Refer to the provider documentation for
>  details.
>  
>  (and 4 more similar warnings elsewhere)

This PR replaces the line `region = data.aws_region.current.name` -> `region = data.aws_region.current.region`

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #471

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
