### PR TITLE
ci: Scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   main:
     name: Validate PR title

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -16,6 +16,9 @@ on:
 env:
   PYTHON_VERSION: 3.11
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Deploy docs


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.