### PR TITLE
fix: Updated data resource for aws_region in main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "time_sleep" "this" {
 locals {
   account_id = data.aws_caller_identity.current.account_id
   partition  = data.aws_partition.current.partition
-  region     = data.aws_region.current.name
+  region     = data.aws_region.current.region
 
   # Threads the sleep resource into the module to make the dependency
   cluster_endpoint  = time_sleep.this.triggers["cluster_endpoint"]


### PR DESCRIPTION
name - (Optional, Deprecated) Full name of the region to select. Use region instead.

data.aws_region.current.name has been Deprecated
[Here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region#:~:text=name%20%2D%20(Optional%2C%20Deprecated)%20Full%20name%20of%20the%20region%20to%20select.%20Use%20region%20instead.)



### What does this PR do?

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #<issue-number>

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
