### PR TITLE
fixed deprecated aws_region attribute

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "time_sleep" "this" {
 locals {
   account_id = data.aws_caller_identity.current.account_id
   partition  = data.aws_partition.current.partition
-  region     = data.aws_region.current.name
+  region     = data.aws_region.current.region
 
   # Threads the sleep resource into the module to make the dependency
   cluster_endpoint  = time_sleep.this.triggers["cluster_endpoint"]


### PR DESCRIPTION
### What does this PR do?

Updates the deprecated `data.aws_region.current.name` with `data.aws_region.current.region` in main.tf.

Problem

The AWS provider deprecated the name attribute on the aws_region data source. This causes a warning on every plan/apply:

```hcl
Warning: Deprecated attribute

on .terraform/modules/eks_blueprints_addons/main.tf line 21, in locals:
21:   region = data.aws_region.current.name
```

Solution

Change line 21 in main.tf from `region = data.aws_region.current.name` -> `region = data.aws_region.current.region`

References

  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region


🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

just a slight personal annoyance of low-hanging fruit.

### More

I have tested on my own project using the latest Terraform provider:

```hcl
terraform {
  required_version = "~> 1.14"
...
}
```

Have not tested anything outside of that.

The test results are that the warning message is no longer displayed.

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
