### PR TITLE
feat(irsa): allow custom trust policy statements on IAM roles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         args: ['--markdown-linebreak-ext=md']
@@ -11,9 +11,10 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.99.4
+    rev: v1.104.0
     hooks:
       - id: terraform_fmt
+      - id: terraform_validate
       - id: terraform_docs
         args:
           - '--args=--lockfile=false'
@@ -34,4 +35,3 @@ repos:
           - '--args=--only=terraform_workspace_remote'
           - '--args=--only=terraform_empty_list_equality'
           - '--args=--only=terraform_unused_required_providers'
-      - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.104.0
+    rev: v1.108.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -88,36 +88,36 @@ module "eks" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_argo_events"></a> [argo\_events](#module\_argo\_events) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_argo_rollouts"></a> [argo\_rollouts](#module\_argo\_rollouts) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_argo_workflows"></a> [argo\_workflows](#module\_argo\_workflows) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_argocd"></a> [argocd](#module\_argocd) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_aws_cloudwatch_metrics"></a> [aws\_cloudwatch\_metrics](#module\_aws\_cloudwatch\_metrics) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_aws_efs_csi_driver"></a> [aws\_efs\_csi\_driver](#module\_aws\_efs\_csi\_driver) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_aws_for_fluentbit"></a> [aws\_for\_fluentbit](#module\_aws\_for\_fluentbit) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_aws_fsx_csi_driver"></a> [aws\_fsx\_csi\_driver](#module\_aws\_fsx\_csi\_driver) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_aws_gateway_api_controller"></a> [aws\_gateway\_api\_controller](#module\_aws\_gateway\_api\_controller) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_aws_load_balancer_controller"></a> [aws\_load\_balancer\_controller](#module\_aws\_load\_balancer\_controller) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_aws_node_termination_handler"></a> [aws\_node\_termination\_handler](#module\_aws\_node\_termination\_handler) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
+| <a name="module_argo_events"></a> [argo\_events](#module\_argo\_events) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_argo_rollouts"></a> [argo\_rollouts](#module\_argo\_rollouts) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_argo_workflows"></a> [argo\_workflows](#module\_argo\_workflows) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_argocd"></a> [argocd](#module\_argocd) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_aws_cloudwatch_metrics"></a> [aws\_cloudwatch\_metrics](#module\_aws\_cloudwatch\_metrics) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_aws_efs_csi_driver"></a> [aws\_efs\_csi\_driver](#module\_aws\_efs\_csi\_driver) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_aws_for_fluentbit"></a> [aws\_for\_fluentbit](#module\_aws\_for\_fluentbit) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_aws_fsx_csi_driver"></a> [aws\_fsx\_csi\_driver](#module\_aws\_fsx\_csi\_driver) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_aws_gateway_api_controller"></a> [aws\_gateway\_api\_controller](#module\_aws\_gateway\_api\_controller) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_aws_load_balancer_controller"></a> [aws\_load\_balancer\_controller](#module\_aws\_load\_balancer\_controller) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_aws_node_termination_handler"></a> [aws\_node\_termination\_handler](#module\_aws\_node\_termination\_handler) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
 | <a name="module_aws_node_termination_handler_sqs"></a> [aws\_node\_termination\_handler\_sqs](#module\_aws\_node\_termination\_handler\_sqs) | terraform-aws-modules/sqs/aws | 4.0.1 |
-| <a name="module_aws_privateca_issuer"></a> [aws\_privateca\_issuer](#module\_aws\_privateca\_issuer) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_bottlerocket_shadow"></a> [bottlerocket\_shadow](#module\_bottlerocket\_shadow) | aws-ia/eks-blueprints-addon/aws | ~> 1.1.1 |
-| <a name="module_bottlerocket_update_operator"></a> [bottlerocket\_update\_operator](#module\_bottlerocket\_update\_operator) | aws-ia/eks-blueprints-addon/aws | ~> 1.1.1 |
-| <a name="module_cert_manager"></a> [cert\_manager](#module\_cert\_manager) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_cluster_autoscaler"></a> [cluster\_autoscaler](#module\_cluster\_autoscaler) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_cluster_proportional_autoscaler"></a> [cluster\_proportional\_autoscaler](#module\_cluster\_proportional\_autoscaler) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_external_dns"></a> [external\_dns](#module\_external\_dns) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_external_secrets"></a> [external\_secrets](#module\_external\_secrets) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_gatekeeper"></a> [gatekeeper](#module\_gatekeeper) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_ingress_nginx"></a> [ingress\_nginx](#module\_ingress\_nginx) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
+| <a name="module_aws_privateca_issuer"></a> [aws\_privateca\_issuer](#module\_aws\_privateca\_issuer) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_bottlerocket_shadow"></a> [bottlerocket\_shadow](#module\_bottlerocket\_shadow) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_bottlerocket_update_operator"></a> [bottlerocket\_update\_operator](#module\_bottlerocket\_update\_operator) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_cert_manager"></a> [cert\_manager](#module\_cert\_manager) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_cluster_autoscaler"></a> [cluster\_autoscaler](#module\_cluster\_autoscaler) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_cluster_proportional_autoscaler"></a> [cluster\_proportional\_autoscaler](#module\_cluster\_proportional\_autoscaler) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_external_dns"></a> [external\_dns](#module\_external\_dns) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_external_secrets"></a> [external\_secrets](#module\_external\_secrets) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_gatekeeper"></a> [gatekeeper](#module\_gatekeeper) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_ingress_nginx"></a> [ingress\_nginx](#module\_ingress\_nginx) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_karpenter"></a> [karpenter](#module\_karpenter) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
 | <a name="module_karpenter_sqs"></a> [karpenter\_sqs](#module\_karpenter\_sqs) | terraform-aws-modules/sqs/aws | 4.0.1 |
-| <a name="module_kube_prometheus_stack"></a> [kube\_prometheus\_stack](#module\_kube\_prometheus\_stack) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_metrics_server"></a> [metrics\_server](#module\_metrics\_server) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_secrets_store_csi_driver"></a> [secrets\_store\_csi\_driver](#module\_secrets\_store\_csi\_driver) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_secrets_store_csi_driver_provider_aws"></a> [secrets\_store\_csi\_driver\_provider\_aws](#module\_secrets\_store\_csi\_driver\_provider\_aws) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_velero"></a> [velero](#module\_velero) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
-| <a name="module_vpa"></a> [vpa](#module\_vpa) | aws-ia/eks-blueprints-addon/aws | 1.1.1 |
+| <a name="module_kube_prometheus_stack"></a> [kube\_prometheus\_stack](#module\_kube\_prometheus\_stack) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_metrics_server"></a> [metrics\_server](#module\_metrics\_server) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_secrets_store_csi_driver"></a> [secrets\_store\_csi\_driver](#module\_secrets\_store\_csi\_driver) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_secrets_store_csi_driver_provider_aws"></a> [secrets\_store\_csi\_driver\_provider\_aws](#module\_secrets\_store\_csi\_driver\_provider\_aws) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_velero"></a> [velero](#module\_velero) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
+| <a name="module_vpa"></a> [vpa](#module\_vpa) | aws-ia/eks-blueprints-addon/aws | 1.2.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -98,7 +98,8 @@ locals {
 
 module "argo_rollouts" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_argo_rollouts
 
@@ -154,7 +155,8 @@ module "argo_rollouts" {
 
 module "argo_workflows" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_argo_workflows
 
@@ -210,7 +212,8 @@ module "argo_workflows" {
 
 module "argocd" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_argocd
 
@@ -266,7 +269,8 @@ module "argocd" {
 
 module "argo_events" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_argo_events
 
@@ -327,7 +331,8 @@ locals {
 
 module "aws_cloudwatch_metrics" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_aws_cloudwatch_metrics
 
@@ -406,6 +411,8 @@ module "aws_cloudwatch_metrics" {
       service_account = local.aws_cloudwatch_metrics_service_account
     }
   }
+
+  trust_policy_statements = try(var.aws_cloudwatch_metrics.trust_policy_statements, null)
 
   tags = var.tags
 }
@@ -496,7 +503,8 @@ data "aws_iam_policy_document" "aws_efs_csi_driver" {
 
 module "aws_efs_csi_driver" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_aws_efs_csi_driver
 
@@ -586,6 +594,8 @@ module "aws_efs_csi_driver" {
     }
   }
 
+  trust_policy_statements = try(var.aws_efs_csi_driver.trust_policy_statements, null)
+
   tags = var.tags
 }
 
@@ -673,7 +683,8 @@ data "aws_iam_policy_document" "aws_for_fluentbit" {
 
 module "aws_for_fluentbit" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_aws_for_fluentbit
 
@@ -772,6 +783,8 @@ module "aws_for_fluentbit" {
       service_account = local.aws_for_fluentbit_service_account
     }
   }
+
+  trust_policy_statements = try(var.aws_for_fluentbit.trust_policy_statements, null)
 
   tags = var.tags
 }
@@ -1069,7 +1082,8 @@ data "aws_iam_policy_document" "aws_fsx_csi_driver" {
 
 module "aws_fsx_csi_driver" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_aws_fsx_csi_driver
 
@@ -1158,6 +1172,8 @@ module "aws_fsx_csi_driver" {
       service_account = local.aws_fsx_csi_driver_node_service_account
     }
   }
+
+  trust_policy_statements = try(var.aws_fsx_csi_driver.trust_policy_statements, null)
 }
 
 ################################################################################
@@ -1440,7 +1456,8 @@ data "aws_iam_policy_document" "aws_load_balancer_controller" {
 
 module "aws_load_balancer_controller" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_aws_load_balancer_controller
 
@@ -1521,6 +1538,8 @@ module "aws_load_balancer_controller" {
       service_account = local.aws_load_balancer_controller_service_account
     }
   }
+
+  trust_policy_statements = try(var.aws_load_balancer_controller.trust_policy_statements, null)
 
   tags = var.tags
 }
@@ -1661,7 +1680,8 @@ data "aws_iam_policy_document" "aws_node_termination_handler" {
 
 module "aws_node_termination_handler" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_aws_node_termination_handler
 
@@ -1752,6 +1772,8 @@ module "aws_node_termination_handler" {
     }
   }
 
+  trust_policy_statements = try(var.aws_node_termination_handler.trust_policy_statements, null)
+
   tags = var.tags
 }
 
@@ -1785,7 +1807,8 @@ data "aws_iam_policy_document" "aws_privateca_issuer" {
 
 module "aws_privateca_issuer" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_aws_privateca_issuer
 
@@ -1863,6 +1886,8 @@ module "aws_privateca_issuer" {
     }
   }
 
+  trust_policy_statements = try(var.aws_privateca_issuer.trust_policy_statements, null)
+
   tags = var.tags
 }
 
@@ -1903,7 +1928,8 @@ data "aws_iam_policy_document" "cert_manager" {
 
 module "cert_manager" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_cert_manager
 
@@ -1987,6 +2013,8 @@ module "cert_manager" {
     }
   }
 
+  trust_policy_statements = try(var.cert_manager.trust_policy_statements, null)
+
   tags = var.tags
 }
 
@@ -2060,7 +2088,8 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
 
 module "cluster_autoscaler" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_cluster_autoscaler
 
@@ -2152,6 +2181,8 @@ module "cluster_autoscaler" {
     }
   }
 
+  trust_policy_statements = try(var.cluster_autoscaler.trust_policy_statements, null)
+
   tags = var.tags
 }
 
@@ -2161,7 +2192,8 @@ module "cluster_autoscaler" {
 
 module "cluster_proportional_autoscaler" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_cluster_proportional_autoscaler
 
@@ -2286,7 +2318,8 @@ data "aws_iam_policy_document" "external_dns" {
 
 module "external_dns" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_external_dns
 
@@ -2364,6 +2397,8 @@ module "external_dns" {
     }
   }
 
+  trust_policy_statements = try(var.external_dns.trust_policy_statements, null)
+
   tags = var.tags
 }
 
@@ -2439,7 +2474,8 @@ data "aws_iam_policy_document" "external_secrets" {
 
 module "external_secrets" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_external_secrets
 
@@ -2520,6 +2556,8 @@ module "external_secrets" {
       service_account = local.external_secrets_service_account
     }
   }
+
+  trust_policy_statements = try(var.external_secrets.trust_policy_statements, null)
 
   tags = var.tags
 }
@@ -2689,7 +2727,8 @@ resource "kubernetes_config_map_v1" "aws_logging" {
 
 module "gatekeeper" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_gatekeeper
 
@@ -2745,7 +2784,8 @@ module "gatekeeper" {
 
 module "ingress_nginx" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_ingress_nginx
 
@@ -3070,7 +3110,8 @@ resource "aws_iam_instance_profile" "karpenter" {
 
 module "karpenter" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_karpenter
 
@@ -3145,6 +3186,8 @@ module "karpenter" {
     }
   }
 
+  trust_policy_statements = try(var.karpenter.trust_policy_statements, null)
+
   tags = var.tags
 }
 
@@ -3165,7 +3208,8 @@ module "karpenter" {
 
 module "kube_prometheus_stack" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_kube_prometheus_stack
 
@@ -3221,7 +3265,8 @@ module "kube_prometheus_stack" {
 
 module "metrics_server" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_metrics_server
 
@@ -3277,7 +3322,8 @@ module "metrics_server" {
 
 module "secrets_store_csi_driver" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_secrets_store_csi_driver
 
@@ -3333,7 +3379,8 @@ module "secrets_store_csi_driver" {
 
 module "secrets_store_csi_driver_provider_aws" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_secrets_store_csi_driver_provider_aws
 
@@ -3446,7 +3493,8 @@ data "aws_iam_policy_document" "velero" {
 
 module "velero" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_velero
 
@@ -3559,6 +3607,8 @@ module "velero" {
     }
   }
 
+  trust_policy_statements = try(var.velero.trust_policy_statements, null)
+
   tags = var.tags
 }
 
@@ -3568,7 +3618,8 @@ module "velero" {
 
 module "vpa" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_vpa
 
@@ -3661,7 +3712,8 @@ data "aws_iam_policy_document" "aws_gateway_api_controller" {
 
 module "aws_gateway_api_controller" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "1.1.1"
+  version = "1.2.0"
+
 
   create = var.enable_aws_gateway_api_controller
 
@@ -3745,6 +3797,8 @@ module "aws_gateway_api_controller" {
     }
   }
 
+  trust_policy_statements = try(var.aws_gateway_api_controller.trust_policy_statements, null)
+
   tags = var.tags
 }
 
@@ -3758,7 +3812,7 @@ locals {
 
 module "bottlerocket_shadow" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "~> 1.1.1"
+  version = "1.2.0"
 
   create = var.enable_bottlerocket_update_operator
 
@@ -3810,7 +3864,7 @@ module "bottlerocket_shadow" {
 
 module "bottlerocket_update_operator" {
   source  = "aws-ia/eks-blueprints-addon/aws"
-  version = "~> 1.1.1"
+  version = "1.2.0"
 
   create = var.enable_bottlerocket_update_operator
 


### PR DESCRIPTION
### What does this PR do?

> ⚠️ **This PR is not ready to merge yet.** It depends on [aws-ia/terraform-aws-eks-blueprints-addon#43](https://github.com/aws-ia/terraform-aws-eks-blueprints-addon/pull/43) being released. Once the new version is published, this PR will be ready for review.


Add `trust_policy_statements` attribute to all modules that create IAM roles for service accounts (IRSA). This allows users to customize the trust policy of the IAM roles by adding additional statements.

The following modules now support `trust_policy_statements`:
- `aws_cloudwatch_metrics`
- `aws_efs_csi_driver`
- `aws_for_fluentbit`
- `aws_fsx_csi_driver`
- `aws_load_balancer_controller`
- `aws_node_termination_handler`
- `aws_privateca_issuer`
- `cert_manager`
- `cluster_autoscaler`
- `external_dns`
- `external_secrets`
- `karpenter`
- `velero`
- `aws_gateway_api_controller`

This attribute is only added to modules that have the `create_role` option, as it is only relevant when an IAM role is being created.

Also updates `aws-ia/eks-blueprints-addon` module version to `1.2.0` for all addons including `bottlerocket_shadow` and `bottlerocket_update_operator`.

### Motivation

Enable users to add additional trust policy statements to IRSA roles when needed, such as:
- **Smooth migration to EKS Pod Identity**: organizations can progressively migrate from IRSA to Pod Identity by adding the Pod Identity trust relationship to existing IAM roles, allowing both authentication methods to coexist during the transition
- Cross-account access scenarios
- Additional service principals
- Custom federation configurations

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

**Example usage:**

```hcl
module "irsa_extra_statements" {
  source  = "aws-ia/eks-blueprints-addon/aws"
  version = "1.2.0"

  # Disable helm release
  create_release = false

  # IAM role for service account (IRSA + extra statements)
  create_role = true
  role_name   = "aws-vpc-cni-ipv4"
  role_policies = {
    AmazonEKS_CNI_Policy = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
  }

  oidc_providers = {
    this = {
      provider_arn    = module.eks.oidc_provider_arn
      namespace       = "kube-system"
      service_account = "aws-node"
    }
  }

  trust_policy_statements = [
    {
      sid    = "PodIdentity"
      effect = "Allow"
      actions = [
        "sts:AssumeRole",
        "sts:TagSession",
      ]
      principals = [
        {
          type        = "Service"
          identifiers = ["pods.eks.amazonaws.com"]
        }
      ]
    }
  ]

  tags = local.tags
}
```