### PR TITLE
feat: Upgrade Helm to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ module "eks" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.9, < 3.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.20 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
@@ -79,7 +79,7 @@ module "eks" {
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.9, < 3.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 3.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.20 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.6 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.9 |

--- a/helm.tf
+++ b/helm.tf
@@ -39,35 +39,9 @@ resource "helm_release" "this" {
   dependency_update          = try(each.value.dependency_update, null)
   replace                    = try(each.value.replace, null)
   lint                       = try(each.value.lint, null)
-
-  dynamic "postrender" {
-    for_each = try([each.value.postrender], [])
-
-    content {
-      binary_path = postrender.value.binary_path
-      args        = try(postrender.value.args, null)
-    }
-  }
-
-  dynamic "set" {
-    for_each = try(each.value.set, [])
-
-    content {
-      name  = set.value.name
-      value = set.value.value
-      type  = try(set.value.type, null)
-    }
-  }
-
-  dynamic "set_sensitive" {
-    for_each = try(each.value.set_sensitive, [])
-
-    content {
-      name  = set_sensitive.value.name
-      value = set_sensitive.value.value
-      type  = try(set_sensitive.value.type, null)
-    }
-  }
+  postrender                 = try(each.value.postrender, [])
+  set                        = try(each.value.set, [])
+  set_sensitive              = try(each.value.set_sensitive, [])
 
   depends_on = [
     # Wait for EBS CSI, etc. to be installed first

--- a/tests/complete/README.md
+++ b/tests/complete/README.md
@@ -34,7 +34,7 @@ terraform destroy
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.9, < 3.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.20 |
 
 ## Providers

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -21,11 +21,11 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
 
-    exec {
+    exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed

--- a/tests/complete/versions.tf
+++ b/tests/complete/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9, < 3.0"
+      version = ">= 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9, < 3.0"
+      version = ">= 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
New attempt because https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/pull/472 got closed by GitHub Actions

⚠️ WIP: depends on https://github.com/aws-ia/terraform-aws-eks-blueprints-addon/pull/42 being merged first

### What does this PR do?

As requested in https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/issues/452, this upgrades the Helm provider to v3.

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolves #452

### More

- [ ] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
