### PR TITLE
feat: Update AWS LB Controller IAM policy and add AGA policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,11 @@ module "eks" {
 | [aws_cloudwatch_log_group.fargate_fluentbit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_eks_addon.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_iam_instance_profile.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_policy.aws_load_balancer_controller_aga](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.fargate_fluentbit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.aws_load_balancer_controller_aga](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_config_map_v1.aws_logging](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1) | resource |
@@ -151,6 +153,7 @@ module "eks" {
 | [aws_iam_policy_document.aws_fsx_csi_driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.aws_gateway_api_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.aws_load_balancer_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.aws_load_balancer_controller_aga](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.aws_node_termination_handler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.aws_privateca_issuer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -187,7 +190,7 @@ module "eks" {
 | <a name="input_bottlerocket_shadow"></a> [bottlerocket\_shadow](#input\_bottlerocket\_shadow) | Bottlerocket Update Operator CRDs configuration values | `any` | `{}` | no |
 | <a name="input_bottlerocket_update_operator"></a> [bottlerocket\_update\_operator](#input\_bottlerocket\_update\_operator) | Bottlerocket Update Operator add-on configuration values | `any` | `{}` | no |
 | <a name="input_cert_manager"></a> [cert\_manager](#input\_cert\_manager) | cert-manager add-on configuration values | `any` | `{}` | no |
-| <a name="input_cert_manager_route53_hosted_zone_arns"></a> [cert\_manager\_route53\_hosted\_zone\_arns](#input\_cert\_manager\_route53\_hosted\_zone\_arns) | List of Route53 Hosted Zone ARNs that are used by cert-manager to create DNS records | `list(string)` | <pre>[<br/>  "arn:aws:route53:::hostedzone/*"<br/>]</pre> | no |
+| <a name="input_cert_manager_route53_hosted_zone_arns"></a> [cert\_manager\_route53\_hosted\_zone\_arns](#input\_cert\_manager\_route53\_hosted\_zone\_arns) | List of Route53 Hosted Zone ARNs that are used by cert-manager to create DNS records | `list(string)` | <pre>[<br>  "arn:aws:route53:::hostedzone/*"<br>]</pre> | no |
 | <a name="input_cluster_autoscaler"></a> [cluster\_autoscaler](#input\_cluster\_autoscaler) | Cluster Autoscaler add-on configuration values | `any` | `{}` | no |
 | <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | Endpoint for your Kubernetes API server | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the EKS cluster | `string` | n/a | yes |
@@ -208,6 +211,7 @@ module "eks" {
 | <a name="input_enable_aws_fsx_csi_driver"></a> [enable\_aws\_fsx\_csi\_driver](#input\_enable\_aws\_fsx\_csi\_driver) | Enable AWS FSX CSI Driver add-on | `bool` | `false` | no |
 | <a name="input_enable_aws_gateway_api_controller"></a> [enable\_aws\_gateway\_api\_controller](#input\_enable\_aws\_gateway\_api\_controller) | Enable AWS Gateway API Controller add-on | `bool` | `false` | no |
 | <a name="input_enable_aws_load_balancer_controller"></a> [enable\_aws\_load\_balancer\_controller](#input\_enable\_aws\_load\_balancer\_controller) | Enable AWS Load Balancer Controller add-on | `bool` | `false` | no |
+| <a name="input_enable_aws_load_balancer_controller_aga"></a> [enable\_aws\_load\_balancer\_controller\_aga](#input\_enable\_aws\_load\_balancer\_controller\_aga) | Enable AWS Load Balancer Controller Global Accelerator (AGA) IAM policy | `bool` | `false` | no |
 | <a name="input_enable_aws_node_termination_handler"></a> [enable\_aws\_node\_termination\_handler](#input\_enable\_aws\_node\_termination\_handler) | Enable AWS Node Termination Handler add-on | `bool` | `false` | no |
 | <a name="input_enable_aws_privateca_issuer"></a> [enable\_aws\_privateca\_issuer](#input\_enable\_aws\_privateca\_issuer) | Enable AWS PCA Issuer | `bool` | `false` | no |
 | <a name="input_enable_bottlerocket_update_operator"></a> [enable\_bottlerocket\_update\_operator](#input\_enable\_bottlerocket\_update\_operator) | Enable Bottlerocket Update Operator add-on | `bool` | `false` | no |
@@ -230,9 +234,9 @@ module "eks" {
 | <a name="input_external_dns"></a> [external\_dns](#input\_external\_dns) | external-dns add-on configuration values | `any` | `{}` | no |
 | <a name="input_external_dns_route53_zone_arns"></a> [external\_dns\_route53\_zone\_arns](#input\_external\_dns\_route53\_zone\_arns) | List of Route53 zones ARNs which external-dns will have access to create/manage records (if using Route53) | `list(string)` | `[]` | no |
 | <a name="input_external_secrets"></a> [external\_secrets](#input\_external\_secrets) | External Secrets add-on configuration values | `any` | `{}` | no |
-| <a name="input_external_secrets_kms_key_arns"></a> [external\_secrets\_kms\_key\_arns](#input\_external\_secrets\_kms\_key\_arns) | List of KMS Key ARNs that are used by Secrets Manager that contain secrets to mount using External Secrets | `list(string)` | <pre>[<br/>  "arn:aws:kms:*:*:key/*"<br/>]</pre> | no |
-| <a name="input_external_secrets_secrets_manager_arns"></a> [external\_secrets\_secrets\_manager\_arns](#input\_external\_secrets\_secrets\_manager\_arns) | List of Secrets Manager ARNs that contain secrets to mount using External Secrets | `list(string)` | <pre>[<br/>  "arn:aws:secretsmanager:*:*:secret:*"<br/>]</pre> | no |
-| <a name="input_external_secrets_ssm_parameter_arns"></a> [external\_secrets\_ssm\_parameter\_arns](#input\_external\_secrets\_ssm\_parameter\_arns) | List of Systems Manager Parameter ARNs that contain secrets to mount using External Secrets | `list(string)` | <pre>[<br/>  "arn:aws:ssm:*:*:parameter/*"<br/>]</pre> | no |
+| <a name="input_external_secrets_kms_key_arns"></a> [external\_secrets\_kms\_key\_arns](#input\_external\_secrets\_kms\_key\_arns) | List of KMS Key ARNs that are used by Secrets Manager that contain secrets to mount using External Secrets | `list(string)` | <pre>[<br>  "arn:aws:kms:*:*:key/*"<br>]</pre> | no |
+| <a name="input_external_secrets_secrets_manager_arns"></a> [external\_secrets\_secrets\_manager\_arns](#input\_external\_secrets\_secrets\_manager\_arns) | List of Secrets Manager ARNs that contain secrets to mount using External Secrets | `list(string)` | <pre>[<br>  "arn:aws:secretsmanager:*:*:secret:*"<br>]</pre> | no |
+| <a name="input_external_secrets_ssm_parameter_arns"></a> [external\_secrets\_ssm\_parameter\_arns](#input\_external\_secrets\_ssm\_parameter\_arns) | List of Systems Manager Parameter ARNs that contain secrets to mount using External Secrets | `list(string)` | <pre>[<br>  "arn:aws:ssm:*:*:parameter/*"<br>]</pre> | no |
 | <a name="input_fargate_fluentbit"></a> [fargate\_fluentbit](#input\_fargate\_fluentbit) | Fargate fluentbit add-on config | `any` | `{}` | no |
 | <a name="input_fargate_fluentbit_cw_log_group"></a> [fargate\_fluentbit\_cw\_log\_group](#input\_fargate\_fluentbit\_cw\_log\_group) | AWS Fargate Fluentbit CloudWatch Log Group configurations | `any` | `{}` | no |
 | <a name="input_gatekeeper"></a> [gatekeeper](#input\_gatekeeper) | Gatekeeper add-on configuration | `any` | `{}` | no |
@@ -267,6 +271,7 @@ module "eks" {
 | <a name="output_aws_fsx_csi_driver"></a> [aws\_fsx\_csi\_driver](#output\_aws\_fsx\_csi\_driver) | Map of attributes of the Helm release and IRSA created |
 | <a name="output_aws_gateway_api_controller"></a> [aws\_gateway\_api\_controller](#output\_aws\_gateway\_api\_controller) | Map of attributes of the Helm release and IRSA created |
 | <a name="output_aws_load_balancer_controller"></a> [aws\_load\_balancer\_controller](#output\_aws\_load\_balancer\_controller) | Map of attributes of the Helm release and IRSA created |
+| <a name="output_aws_load_balancer_controller_aga"></a> [aws\_load\_balancer\_controller\_aga](#output\_aws\_load\_balancer\_controller\_aga) | Map of attributes of the Global Accelerator IAM policy for AWS Load Balancer Controller |
 | <a name="output_aws_node_termination_handler"></a> [aws\_node\_termination\_handler](#output\_aws\_node\_termination\_handler) | Map of attributes of the Helm release and IRSA created |
 | <a name="output_aws_privateca_issuer"></a> [aws\_privateca\_issuer](#output\_aws\_privateca\_issuer) | Map of attributes of the Helm release and IRSA created |
 | <a name="output_bottlerocket_update_operator"></a> [bottlerocket\_update\_operator](#output\_bottlerocket\_update\_operator) | Map of attributes of the Helm release and IRSA created |

--- a/main.tf
+++ b/main.tf
@@ -1204,6 +1204,7 @@ data "aws_iam_policy_document" "aws_load_balancer_controller" {
       "ec2:DescribeCoipPools",
       "ec2:GetSecurityGroupsForVpc",
       "ec2:DescribeIpamPools",
+      "ec2:DescribeRouteTables",
       "elasticloadbalancing:DescribeLoadBalancers",
       "elasticloadbalancing:DescribeLoadBalancerAttributes",
       "elasticloadbalancing:DescribeListeners",
@@ -1523,6 +1524,174 @@ module "aws_load_balancer_controller" {
   }
 
   tags = var.tags
+}
+
+################################################################################
+# AWS Load Balancer Controller - Global Accelerator (AGA) Policy
+################################################################################
+
+# https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/install/aga_controller_iam_policy.json
+data "aws_iam_policy_document" "aws_load_balancer_controller_aga" {
+  count = var.enable_aws_load_balancer_controller_aga ? 1 : 0
+
+  statement {
+    actions   = ["iam:CreateServiceLinkedRole"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "iam:AWSServiceName"
+      values   = ["globalaccelerator.amazonaws.com"]
+    }
+  }
+
+  statement {
+    actions = [
+      "globalaccelerator:ListAccelerators",
+      "globalaccelerator:ListEndpointGroups",
+      "globalaccelerator:ListListeners",
+      "globalaccelerator:ListTagsForResource",
+      "ec2:DescribeRegions",
+      "tag:GetResources",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "globalaccelerator:DescribeAccelerator",
+      "globalaccelerator:DescribeEndpointGroup",
+      "globalaccelerator:DescribeListener",
+    ]
+    resources = [
+      "arn:${local.partition}:globalaccelerator::*:accelerator/*",
+      "arn:${local.partition}:globalaccelerator::*:accelerator/*/listener/*",
+      "arn:${local.partition}:globalaccelerator::*:accelerator/*/listener/*/endpoint-group/*",
+    ]
+
+    condition {
+      test     = "Null"
+      variable = "aws:ResourceTag/elbv2.k8s.aws/cluster"
+      values   = ["false"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/aga.k8s.aws/resource"
+      values   = ["GlobalAccelerator"]
+    }
+  }
+
+  statement {
+    actions   = ["globalaccelerator:CreateAccelerator"]
+    resources = ["*"]
+
+    condition {
+      test     = "Null"
+      variable = "aws:RequestTag/elbv2.k8s.aws/cluster"
+      values   = ["false"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/aga.k8s.aws/resource"
+      values   = ["GlobalAccelerator"]
+    }
+  }
+
+  statement {
+    actions = [
+      "globalaccelerator:UpdateAccelerator",
+      "globalaccelerator:DeleteAccelerator",
+      "globalaccelerator:CreateListener",
+      "globalaccelerator:UpdateListener",
+      "globalaccelerator:DeleteListener",
+      "globalaccelerator:CreateEndpointGroup",
+      "globalaccelerator:UpdateEndpointGroup",
+      "globalaccelerator:DeleteEndpointGroup",
+      "globalaccelerator:AddEndpoints",
+      "globalaccelerator:RemoveEndpoints",
+    ]
+    resources = [
+      "arn:${local.partition}:globalaccelerator::*:accelerator/*",
+      "arn:${local.partition}:globalaccelerator::*:accelerator/*/listener/*",
+      "arn:${local.partition}:globalaccelerator::*:accelerator/*/listener/*/endpoint-group/*",
+    ]
+
+    condition {
+      test     = "Null"
+      variable = "aws:ResourceTag/elbv2.k8s.aws/cluster"
+      values   = ["false"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/aga.k8s.aws/resource"
+      values   = ["GlobalAccelerator"]
+    }
+  }
+
+  statement {
+    actions = [
+      "globalaccelerator:TagResource",
+      "globalaccelerator:UntagResource",
+    ]
+    resources = ["arn:${local.partition}:globalaccelerator::*:accelerator/*"]
+
+    condition {
+      test     = "Null"
+      variable = "aws:RequestTag/elbv2.k8s.aws/cluster"
+      values   = ["true"]
+    }
+
+    condition {
+      test     = "Null"
+      variable = "aws:ResourceTag/elbv2.k8s.aws/cluster"
+      values   = ["false"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/aga.k8s.aws/resource"
+      values   = ["GlobalAccelerator"]
+    }
+  }
+
+  statement {
+    actions   = ["globalaccelerator:TagResource"]
+    resources = ["arn:${local.partition}:globalaccelerator::*:accelerator/*"]
+
+    condition {
+      test     = "Null"
+      variable = "aws:RequestTag/elbv2.k8s.aws/cluster"
+      values   = ["false"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/aga.k8s.aws/resource"
+      values   = ["GlobalAccelerator"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "aws_load_balancer_controller_aga" {
+  count = var.enable_aws_load_balancer_controller_aga ? 1 : 0
+
+  name        = try(var.aws_load_balancer_controller.aga_policy_name_use_prefix, true) ? null : try(var.aws_load_balancer_controller.aga_policy_name, "aws-load-balancer-controller-aga")
+  name_prefix = try(var.aws_load_balancer_controller.aga_policy_name_use_prefix, true) ? "${try(var.aws_load_balancer_controller.aga_policy_name, "aws-load-balancer-controller-aga")}-" : null
+  path        = try(var.aws_load_balancer_controller.policy_path, null)
+  description = "IAM Policy for AWS Load Balancer Controller - Global Accelerator"
+  policy      = data.aws_iam_policy_document.aws_load_balancer_controller_aga[0].json
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "aws_load_balancer_controller_aga" {
+  count = var.enable_aws_load_balancer_controller_aga ? 1 : 0
+
+  policy_arn = aws_iam_policy.aws_load_balancer_controller_aga[0].arn
+  role       = module.aws_load_balancer_controller.iam_role_name
 }
 
 ################################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -43,6 +43,13 @@ output "aws_load_balancer_controller" {
   value       = module.aws_load_balancer_controller
 }
 
+output "aws_load_balancer_controller_aga" {
+  description = "Map of attributes of the Global Accelerator IAM policy for AWS Load Balancer Controller"
+  value = {
+    iam_policy_arn = try(aws_iam_policy.aws_load_balancer_controller_aga[0].arn, null)
+  }
+}
+
 output "aws_node_termination_handler" {
   description = "Map of attributes of the Helm release and IRSA created"
   value = merge(

--- a/variables.tf
+++ b/variables.tf
@@ -202,6 +202,12 @@ variable "aws_load_balancer_controller" {
   default     = {}
 }
 
+variable "enable_aws_load_balancer_controller_aga" {
+  description = "Enable AWS Load Balancer Controller Global Accelerator (AGA) IAM policy"
+  type        = bool
+  default     = false
+}
+
 ################################################################################
 # AWS Node Termination Handler
 ################################################################################


### PR DESCRIPTION
## Summary
- Add missing `ec2:DescribeRouteTables` permission to the AWS Load Balancer Controller main IAM policy to match [upstream iam_policy.json](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/install/iam_policy.json)
- Add independent Global Accelerator (AGA) IAM policy matching [upstream aga_controller_iam_policy.json](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/install/aga_controller_iam_policy.json), controlled by `enable_aws_load_balancer_controller_aga` variable

## Test plan
- [x] Verify `terraform validate` passes
- [x] Verify `terraform plan` with `enable_aws_load_balancer_controller = true` includes `ec2:DescribeRouteTables`
- [x] Verify `terraform plan` with `enable_aws_load_balancer_controller_aga = true` creates the AGA policy and attachment
- [x] Verify AGA policy is not created when `enable_aws_load_balancer_controller_aga = false` (default)
