### PR TITLE
feat: Update External Secrets Operator Helm chart version to 2.2.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2621,7 +2621,7 @@ module "external_secrets" {
   namespace        = local.external_secrets_namespace
   create_namespace = try(var.external_secrets.create_namespace, true)
   chart            = try(var.external_secrets.chart, "external-secrets")
-  chart_version    = try(var.external_secrets.chart_version, "0.9.13")
+  chart_version    = try(var.external_secrets.chart_version, "2.2.0")
   repository       = try(var.external_secrets.repository, "https://charts.external-secrets.io")
   values           = try(var.external_secrets.values, [])
 


### PR DESCRIPTION
### What does this PR do?

Upgrade External Secrets Operator Helm chart version. Or else it would install only v1alpha1 and v1beta1 version.

### Motivation

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
