### PR TITLE
feat: Allow Karpenter to DescribeCapacityReservations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3035,6 +3035,7 @@ data "aws_iam_policy_document" "karpenter" {
   statement {
     actions = [
       "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeCapacityReservations",
       "ec2:DescribeImages",
       "ec2:DescribeInstances",
       "ec2:DescribeInstanceTypeOfferings",


### PR DESCRIPTION
### What does this PR do?

Add `ec2:DescribeCapacityReservations` to the IAM policy for Karpenter to support https://karpenter.sh/docs/tasks/odcrs/.

<!--
🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted.
Consult the [CONTRIBUTING](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/blob/main/.github/CONTRIBUTING.md#contributing-via-pull-requests) guide for submitting pull-requests.
-->

<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
- Resolve #505 and enable support for ODCRs via the Karpenter blueprint

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

I had intended to more closely mirror https://github.com/aws/karpenter-provider-aws/blob/v1.11.1/website/content/en/docs/reference/cloudformation.md but the following is already rather inclusive, so I didn't bother :sweat_smile:

```hcl
  statement {
    actions = [
      "ec2:CreateFleet",
      "ec2:CreateLaunchTemplate",
      "ec2:CreateTags",
      "ec2:DeleteLaunchTemplate",
      "ec2:RunInstances"
    ]
    resources = [
      "arn:${local.partition}:ec2:${local.region}:${local.account_id}:*",
      "arn:${local.partition}:ec2:${local.region}::image/*"
    ]
  }
```

I have "tested" this PR by manually adding `ec2:DescribeCapacityReservations` to an existing IAM policy that was produced by this repo. After that I was able to configure a NodePool to use an ODCR and spun up a Pod with `nodeSelector: {    karpenter.k8s.aws/capacity-reservation-id: cr-12345678901234567}`.


<!-- Anything else we should know when reviewing? -->
