### PR TITLE
Feature: Add Global Tolerations, Update Add-on Versions, and Configuration Refinements

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.4.0
+      - uses: amannn/action-semantic-pull-request@v5.5.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
### What does this PR do?
This PR introduces several enhancements to the EKS Blueprints add-on configurations to improve flexibility, automation, and stability.

**Key Changes:**
* **Global Tolerations:** Added `global_tolerations` support across all add-on modules, allowing seamless propagation of tolerations to all supported Helm charts.
* **ArgoCD Image Updater:** Integrated the `argocd_image_updater` module to enable automated container image updates.
* **Helm Chart Updates:** Bumped various Helm chart versions to their latest stable releases to incorporate security patches and feature improvements.
* **Configuration Refinement:** Updated `aws_load_balancer_controller` to set `wait = null`, resolving potential deployment stalling issues and webhook errors during resource provisioning.

### Motivation
The inspiration for this PR stems from my personal experience in managing these add-ons, where I encountered significant roadblocks that I want to prevent others from facing:

* **Scheduling Flexibility:** I faced challenges deploying add-ons on custom node groups and Fargate due to the lack of flexible toleration support. Implementing `global_tolerations` allows users to easily configure node affinity/tolerations without hacking individual module files.
* **Deployment Stability:** I encountered a critical race condition where `external-secrets` would attempt to install before the `aws_load_balancer_controller` webhook was fully ready, leading to installation failures. Setting `wait = null` allows for more graceful resource provisioning, preventing these webhook-related errors and ensuring a smoother installation sequence for dependent add-ons.
* **Security & Automation:** Upgrading chart versions and integrating the `argocd_image_updater` ensures the ecosystem remains secure, automated, and up-to-date, saving users from manual maintenance overhead.

### More
- [x] Yes, I have tested the PR using my local account setup.
- [x] Yes, I ran `pre-commit run -a` with this PR.