### PR TITLE
fix: Default Helm add-on postrender to null for Helm provider v3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -375,7 +375,7 @@ module "aws_cloudwatch_metrics" {
   replace                    = try(var.aws_cloudwatch_metrics.replace, null)
   lint                       = try(var.aws_cloudwatch_metrics.lint, null)
 
-  postrender = try(var.aws_cloudwatch_metrics.postrender, [])
+  postrender = try(var.aws_cloudwatch_metrics.postrender, null)
   set = concat(
     [
       {
@@ -547,7 +547,7 @@ module "aws_efs_csi_driver" {
   replace                    = try(var.aws_efs_csi_driver.replace, null)
   lint                       = try(var.aws_efs_csi_driver.lint, null)
 
-  postrender = try(var.aws_efs_csi_driver.postrender, [])
+  postrender = try(var.aws_efs_csi_driver.postrender, null)
   set = concat([
     {
       name  = "controller.serviceAccount.name"
@@ -727,7 +727,7 @@ module "aws_for_fluentbit" {
   replace                    = try(var.aws_for_fluentbit.replace, null)
   lint                       = try(var.aws_for_fluentbit.lint, null)
 
-  postrender = try(var.aws_for_fluentbit.postrender, [])
+  postrender = try(var.aws_for_fluentbit.postrender, null)
   set = concat([
     {
       name  = "serviceAccount.name"
@@ -1126,7 +1126,7 @@ module "aws_fsx_csi_driver" {
   replace                    = try(var.aws_fsx_csi_driver.replace, null)
   lint                       = try(var.aws_fsx_csi_driver.lint, null)
 
-  postrender = try(var.aws_fsx_csi_driver.postrender, [])
+  postrender = try(var.aws_fsx_csi_driver.postrender, null)
   set = concat([
     {
       name  = "controller.serviceAccount.name"
@@ -1502,7 +1502,7 @@ module "aws_load_balancer_controller" {
   replace                    = try(var.aws_load_balancer_controller.replace, null)
   lint                       = try(var.aws_load_balancer_controller.lint, null)
 
-  postrender = try(var.aws_load_balancer_controller.postrender, [])
+  postrender = try(var.aws_load_balancer_controller.postrender, null)
   set = concat([
     {
       name  = "serviceAccount.name"
@@ -1893,7 +1893,7 @@ module "aws_node_termination_handler" {
   replace                    = try(var.aws_node_termination_handler.replace, null)
   lint                       = try(var.aws_node_termination_handler.lint, null)
 
-  postrender = try(var.aws_node_termination_handler.postrender, [])
+  postrender = try(var.aws_node_termination_handler.postrender, null)
   set = concat(
     [
       {
@@ -2020,7 +2020,7 @@ module "aws_privateca_issuer" {
   replace                    = try(var.aws_privateca_issuer.replace, null)
   lint                       = try(var.aws_privateca_issuer.lint, null)
 
-  postrender = try(var.aws_privateca_issuer.postrender, [])
+  postrender = try(var.aws_privateca_issuer.postrender, null)
   set = concat([
     {
       name  = "serviceAccount.name"
@@ -2141,7 +2141,7 @@ module "cert_manager" {
   replace                    = try(var.cert_manager.replace, null)
   lint                       = try(var.cert_manager.lint, null)
 
-  postrender = try(var.cert_manager.postrender, [])
+  postrender = try(var.cert_manager.postrender, null)
   set = concat([
     {
       name  = "installCRDs"
@@ -2301,7 +2301,7 @@ module "cluster_autoscaler" {
   replace                    = try(var.cluster_autoscaler.replace, null)
   lint                       = try(var.cluster_autoscaler.lint, null)
 
-  postrender = try(var.cluster_autoscaler.postrender, [])
+  postrender = try(var.cluster_autoscaler.postrender, null)
   set = concat(
     [
       {
@@ -2531,7 +2531,7 @@ module "external_dns" {
   replace                    = try(var.external_dns.replace, null)
   lint                       = try(var.external_dns.lint, null)
 
-  postrender = try(var.external_dns.postrender, [])
+  postrender = try(var.external_dns.postrender, null)
   set = concat([
     {
       name  = "serviceAccount.name"
@@ -2687,7 +2687,7 @@ module "external_secrets" {
   replace                    = try(var.external_secrets.replace, null)
   lint                       = try(var.external_secrets.lint, null)
 
-  postrender = try(var.external_secrets.postrender, [])
+  postrender = try(var.external_secrets.postrender, null)
   set = concat([
     {
       name  = "serviceAccount.name"
@@ -3323,7 +3323,7 @@ module "karpenter" {
   replace                    = try(var.karpenter.replace, null)
   lint                       = try(var.karpenter.lint, null)
 
-  postrender = try(var.karpenter.postrender, [])
+  postrender = try(var.karpenter.postrender, null)
   set = concat(
     [for s in local.karpenter_set : s if s.value != null],
     try(var.karpenter.set, [])
@@ -3706,7 +3706,7 @@ module "velero" {
   replace                    = try(var.velero.replace, null)
   lint                       = try(var.velero.lint, null)
 
-  postrender = try(var.velero.postrender, [])
+  postrender = try(var.velero.postrender, null)
   set = concat([
     {
       name  = "initContainers"
@@ -3832,7 +3832,7 @@ module "vpa" {
   replace                    = try(var.vpa.replace, null)
   lint                       = try(var.vpa.lint, null)
 
-  postrender = try(var.vpa.postrender, [])
+  postrender = try(var.vpa.postrender, null)
   set = concat([
     {
       name  = "admissionController.enabled"
@@ -3925,7 +3925,7 @@ module "aws_gateway_api_controller" {
   replace                    = try(var.aws_gateway_api_controller.replace, null)
   lint                       = try(var.aws_gateway_api_controller.lint, null)
 
-  postrender = try(var.aws_gateway_api_controller.postrender, [])
+  postrender = try(var.aws_gateway_api_controller.postrender, null)
   set = concat([
     {
       name  = "serviceAccount.name"


### PR DESCRIPTION
> [!NOTE]
> Generated with Claude Code and reviewed manually

### What does this PR do?

Defaults the `postrender` fallback for every Helm-based add-on to `null` instead of an empty tuple (`[]`), fixing a `terraform plan` failure under Helm provider v3.

### Motivation

Since the Helm provider v3 upgrade (#495) and the bump of the `aws-ia/eks-blueprints-addon` helper to v1.3.0 (#512), `helm_release`'s `postrender` is a **single object attribute** (it was a repeatable block under provider v2). The helper module correctly defaults its `var.postrender` to `null`, but this module still forwards each add-on's postrender with an empty-tuple fallback:

```hcl
postrender = try(var.<addon>.postrender, [])
```

An empty tuple is not a valid value for the v3 object attribute, so **any enabled Helm-based add-on that does not explicitly set `postrender`** fails at plan time:

```
Error: Incorrect attribute value type
  on .terraform/modules/.../eks-blueprints-addon/main.tf line 46, in resource "helm_release" "this":
  46:   postrender = var.postrender
  var.postrender is empty tuple

Inappropriate value for attribute "postrender": object required, but have tuple.
```

This reproduces with a minimal config on `v1.24.1` (e.g. `enable_metrics_server = true`) against `hashicorp/helm ~> 3.1`. `terraform validate` passes — only `terraform plan` surfaces it. The empty-tuple fallback is still present on `main`.

The fix changes the 15 `try(..., [])` fallbacks to `try(..., null)`, matching the helper module's own `default = null`. Users who set `postrender` explicitly are unaffected.

### More

- [x] Yes, I have tested the PR using my local account setup (a downstream stack pinning `~> 1.24.1` with `hashicorp/helm 3.1.2` — the type error above is resolved and `plan` proceeds; the identical failure is reproducible before this change)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes

Verified `terraform fmt` and `terraform validate` are clean with this change. `pre-commit run -a` passes cleanly (terraform_fmt, terraform_validate, terraform_docs, terraform_tflint, and the standard hooks) with no file changes. The change is a mechanical fallback-value fix confined to `main.tf` and does not alter any variable/output documentation. Happy to open a tracking issue first if preferred.

